### PR TITLE
shrink m1.small to 10gb disk 

### DIFF
--- a/tools/2-configure/profiles/s390x-multi-lpar-v3
+++ b/tools/2-configure/profiles/s390x-multi-lpar-v3
@@ -33,7 +33,7 @@ secret=$(openstack ec2 credentials show $access  | awk '/secret/ {print $4}')
 
 source novarcv3_project
 openstack flavor show m1.tiny || openstack flavor create   --id 1 --ram 512   --disk 1  --vcpus 1 m1.tiny
-openstack flavor show m1.small || openstack flavor create  --id 2 --ram 2048  --disk 20 --vcpus 1 m1.small
+openstack flavor show m1.small || openstack flavor create  --id 2 --ram 2048  --disk 10 --vcpus 1 m1.small
 openstack flavor show m1.medium || openstack flavor create --id 3 --ram 4096  --disk 40 --vcpus 2 m1.medium
 openstack flavor show m1.large || openstack flavor create  --id 4 --ram 8192  --disk 80 --vcpus 4 m1.large
 openstack flavor show m1.xlarge || openstack flavor create --id 5 --ram 16384 --disk 160 --vcpus 8 m1.xlarge


### PR DESCRIPTION
Because we aren't using ceph, we need to be careful about disk space. 10g allows us enough space to launch xenial, and doesnt go over the disk space in the instance