### PR TITLE
Fix missing dependency to python-glanceclient

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,4 +3,5 @@ python-keystoneclient
 python-neutronclient
 python-novaclient
 python-heatclient
+python-glanceclient
 juju-deployer


### PR DESCRIPTION
The tools/2-configure/profiles/s390x-* scripts use
the glance client.