### PR TITLE
Fix missing image_id in generated tempest template

### DIFF
--- a/tools/2-configure/profiles/s390x-multi-lpar
+++ b/tools/2-configure/profiles/s390x-multi-lpar
@@ -45,7 +45,7 @@ tools/quota_million.sh
 access=$(keystone --os-username demo --os-password pass --os-tenant-name demo ec2-credentials-create | grep access | awk '{ print $4 }')
 secret=$(keystone ec2-credentials-get --access $access | grep secret | awk '{ print $4 }')
 image_id=$(glance image-list | grep cirros | awk '{ print $2 }')
-image_alt_id=$(glance image-list | grep precise | awk '{ print $2 }')
+image_alt_id=$(glance image-list | grep xenial | awk '{ print $2 }')
 ext_net=$(neutron net-list | grep ext_net | awk '{ print $2 }')
 router=$(neutron router-list | grep provider-router | awk '{ print $2}')
 keystone_unit=$(juju status keystone|grep -i workload -A1|tail -n1|awk '{print $1}'|tr -d '*')

--- a/tools/2-configure/profiles/s390x-multi-lpar-v3
+++ b/tools/2-configure/profiles/s390x-multi-lpar-v3
@@ -49,6 +49,8 @@ tools/images_s390x-v3.sh
 tools/sec_groups.sh
 
 echo "Tempest"
+image_id=$(glance image-list | grep cirros | awk '{ print $2 }')
+image_alt_id=$(glance image-list | grep xenial | awk '{ print $2 }')
 router=$(neutron router-list | grep provider-router | awk '{ print $2}')
 # Gather vars for tempest template
 keystone_unit=$(juju status keystone|grep -i workload -A1|tail -n1|awk '{print $1}'|tr -d '*')

--- a/tools/2-configure/profiles/s390x-zkvm
+++ b/tools/2-configure/profiles/s390x-zkvm
@@ -42,7 +42,7 @@ tools/quota_million.sh
 access=$(keystone --os-username demo --os-password pass --os-tenant-name demo ec2-credentials-create | grep access | awk '{ print $4 }')
 secret=$(keystone ec2-credentials-get --access $access | grep secret | awk '{ print $4 }')
 image_id=$(glance image-list | grep cirros | awk '{ print $2 }')
-image_alt_id=$(glance image-list | grep precise | awk '{ print $2 }')
+image_alt_id=$(glance image-list | grep xenial | awk '{ print $2 }')
 ext_net=$(neutron net-list | grep ext_net | awk '{ print $2 }')
 router=$(neutron router-list | grep provider-router | awk '{ print $2}')
 keystone=$(juju-deployer -f keystone)


### PR DESCRIPTION
Without this fix, 14 tempest tests fail with
'Missing imageRef attribute'.
This aligns s390x-multi-lpar-v3 with s390x-multi-plar.

Also align s390x-* scripts with images_s390x* scripts: we're now
downloading xenial instead of precise.

Validated against our s390x lab.