### PR TITLE
Stop pinning Python 2.7

### DIFF
--- a/README-lpar.md
+++ b/README-lpar.md
@@ -28,7 +28,7 @@ The tokenise tool can be found in tools/0-preseed/tokenise.
 There is currently a bug with setting bridge_state after a reboot. It must be set manually after any reboot, e.g.:
 
 ~~~~
-echo primary > /sys/devices/qeth/0.0.c003/bridge_role
+$ echo primary > /sys/devices/qeth/0.0.c003/bridge_role
 ~~~~
 
 
@@ -39,24 +39,26 @@ media" manually and the appropriate preseed selected
 
 ### Bootstrap juju environment
 
-Currently, the easiest way to install juju 2 on z is with via a snap: 
+Currently, the easiest way to install juju 2 on z is with via a snap:
 
 ~~~~
-sudo apt-get install snapd
-sudo snapd install juju --classic
+$ sudo apt-get install snapd
+$ sudo snapd install juju --classic
 ~~~~
 
 To bootstrap:
 
 ~~~~
-juju bootstrap manual/Bootstrap_host_IP controller_name --debug --verbose --constraints arch=architecture
+$ juju bootstrap manual/Bootstrap_host_IP controller_name --debug --verbose --constraints arch=architecture
+~~~~
 
 e.g.
 
-juju bootstrap manual/127.0.0.1 s390x --debug --verbose --constraints arch=s390x
-
-If your controller is behind NAT, you should specify it's 'external' or 'public' IP instead of 127.0.0.1
 ~~~~
+$ juju bootstrap manual/127.0.0.1 s390x --debug --verbose --constraints arch=s390x
+~~~~
+
+If your controller is behind NAT, you should specify its 'external' or 'public' IP instead of 127.0.0.1
 
 
 ### Add machines to juju
@@ -65,25 +67,24 @@ If you have specified a user other than ubuntu in your preseed, change it here.
 You will also need to know the ip address of each LPAR.
 
 ~~~~
-juju add-machine ssh:ubuntu@10.0.0.3
-juju add-machine ssh:ubuntu@10.0.0.4
-juju add-machine ssh:ubuntu@10.0.0.5
-juju add-machine ssh:ubuntu@10.0.0.6
-juju add-machine ssh:ubuntu@10.0.0.7
+$ juju add-machine ssh:ubuntu@10.0.0.3
+$ juju add-machine ssh:ubuntu@10.0.0.4
+$ juju add-machine ssh:ubuntu@10.0.0.5
+$ juju add-machine ssh:ubuntu@10.0.0.6
+$ juju add-machine ssh:ubuntu@10.0.0.7
 ~~~~
 
 ### Clone this repo
 
 ~~~~
-git@github.com:ubuntu-openstack/zopenstack.git
-git checkout multi-lpar-native
+$ git clone https://github.com/ubuntu-openstack/zopenstack
+$ cd zopenstack/
 ~~~~
 
 ### Deploy the openstack bundle
 
 ~~~~
-cd zopenstack
-juju deploy bundles/lpar/xenial-mitaka-stable.yaml --map-machines=existing
+$ juju deploy bundles/lpar/focal-ussuri-next.yaml --map-machines=existing
 ~~~~
 
 ## Configuring Openstack
@@ -92,12 +93,13 @@ juju deploy bundles/lpar/xenial-mitaka-stable.yaml --map-machines=existing
 The openstack-charm-testing repo provides scripts and profiles
 to configure an openstack environment.
 
-simply run 
+simply run
 
 ~~~~
-cd tools/2-configure
-source openrc
-./configure s390x-multi-lpar
+$ tox -e clients
+$ . .tox/clients/bin/activate
+(clients) $ cd tools/2-configure/
+(clients) $ ./configure s390x-multi-lpar-v3
 ~~~~
 
 Once the configuration is complete, you can move onto the testing phase
@@ -108,23 +110,24 @@ Once the configuration is complete, you can move onto the testing phase
 You should be able to launch a nova instance as follows:
 
 ~~~~
-# launch some instances
-./tools/instance_launch.sh 5 xenial-s390x
-# give these instances public (ext_net) ip addresses
-./tools/float_all.sh
+(clients) $ # launch some instances
+(clients) $ ./tools/instance_launch.sh 5 xenial-s390x
+(clients) $ # give these instances public (ext_net) ip addresses
+(clients) $ ./tools/float_all.sh
 ~~~~
 
 To see if the instance was launched successfully:
 
 ~~~~
-nova list
+(clients) $ nova list
 ~~~~
 
 If the instance is ready, use the ssh command provided in the instance_launch
 output to see if you can ssh to the nova instance, e.g.:
 
 ~~~~
-ssh -i ~/testkey.pem ubuntu@ip_address
+(clients) $ deactivate
+$ ssh -i ~/testkey.pem ubuntu@ip_address
 ~~~~
 
 ### Tempest testing
@@ -134,7 +137,3 @@ WIP
 ## Collection
 
 WIP
-
-
-
-

--- a/tox.ini
+++ b/tox.ini
@@ -6,16 +6,12 @@ skipsdist = True
 setenv = VIRTUAL_ENV={envdir}
          PYTHONHASHSEED=0
 passenv = HOME TERM
-install_command =
-  pip install --allow-unverified python-apt {opts} {packages}
 
 [testenv:clients]
-basepython = python2.7
 deps = -r{toxinidir}/test-requirements.txt
 commands = openstack --help
 
 [testenv:lint]
-basepython = python2.7
 deps = -r{toxinidir}/test-requirements.txt
 whitelist_externals = bash
 commands = bash tools/3-test/validate_bundles.sh


### PR DESCRIPTION
Our scripts also work fine with Python 3.8 so we can
move on.
Also minor related README refresh.

Validated on our s390x lab.