### PR TITLE
Use Ubuntu images instead of CirrOS for Tempest testing

### DIFF
--- a/tools/2-configure/profiles/s390x-multi-lpar-v3
+++ b/tools/2-configure/profiles/s390x-multi-lpar-v3
@@ -49,11 +49,14 @@ tools/images_s390x-v3.sh
 # Set security groups and rules
 tools/sec_groups.sh
 
-echo "Tempest"
+# Gather vars for tempest template
 image_id=$(glance image-list | grep cirros | awk '{ print $2 }')
 image_alt_id=$(glance image-list | grep xenial | awk '{ print $2 }')
+# NOTE(lourot): There are no CirrOS images for s390x, see lp:1619752, so
+# image_id is probably empty and Tempest will fail. Let's use an Ubuntu image
+# for Tempest testing instead:
+image_id="$image_alt_id"
 router=$(neutron router-list | grep provider-router | awk '{ print $2}')
-# Gather vars for tempest template
 keystone_unit=$(juju status keystone|grep -i workload -A1|tail -n1|awk '{print $1}'|tr -d '*')
 dashboard_unit=$(juju status openstack-dashboard|grep -i workload -A1|tail -n1|awk '{print $1}'|tr -d '*')
 ncc_unit=$(juju status nova-cloud-controller|grep -i workload -A1|tail -n1|awk '{print $1}'|tr -d '*')

--- a/tools/2-configure/templates/tempest/tempest-v3.conf.template
+++ b/tools/2-configure/templates/tempest/tempest-v3.conf.template
@@ -6,6 +6,7 @@ admin_username=admin
 admin_project_name=admin
 admin_password=__ADMIN_PASSWORD__
 admin_domain_name=admin_domain
+
 [compute]
 image_ref=__IMAGE_ID__
 image_ref_alt=__IMAGE_ALT_ID__
@@ -13,14 +14,17 @@ flavor_ref=7
 flavor_ref_alt=8
 region=RegionOne
 min_compute_nodes = 3
+
 [compute-feature-enabled]
 console_output=false
 resize=true
 live_migration=true
 block_migration_for_live_migration=true
+
 [dashboard]
 dashboard_url=__PROTO__://__DASHBOARD__/horizon
 login_url=__PROTO__://__DASHBOARD__/horizon/auth/login/
+
 [identity]
 uri_v3=__PROTO__://__KEYSTONE__:5000/v3
 auth_version=v3
@@ -29,29 +33,37 @@ region=RegionOne
 default_domain_id=__DEFAULT_DOMAIN_ID__
 admin_domain_scope=true
 ca_certificates_file=__ROOT_CA_FILE__
+
 [identity-feature-enabled]
 api_v2=false
 api_v3=true
+
 [image]
 catalog_type = image
 region=RegionOne
 http_image = http://__SWIFT__:80/swift/v1/images/cirros-0.3.4-x86_64-uec.tar.gz
+
 [network]
 project_network_cidr=__CIDR_PRIV__
 public_network_id=__EXT_NET__
 dns_servers=__NAMESERVER__
 project_networks_reachable = false
+
 [network-feature-enabled]
 ipv6=false
+
 [orchestration]
 stack_owner_role = Admin
 instance_type = m1.small
 keypair_name = testkey
+
 [oslo_concurrency]
 lock_path=/tmp
+
 [scenario]
 img_dir=/home/ubuntu/images
 ssh_user=cirros
+
 [service_available]
 ceilometer = true
 cinder = true
@@ -65,12 +77,22 @@ sahara = false
 swift = true
 trove = false
 zaqar = false
+
 [volume]
 catalog_type = volumev3
 backend_names=cinder-ceph
 storage_protocol=ceph
+# NOTE(lourot): We're using Ubuntu images for testing and the default 1GB
+# isn't enough for them:
+volume_size = 5
+
 [volume-feature-enabled]
 backup=false
 api_v1=false
 api_v2=false
 api_v3=true
+
+[validation]
+# NOTE(lourot): We're using Ubuntu images for testing.
+image_ssh_user=ubuntu
+image_alt_ssh_user=ubuntu


### PR DESCRIPTION
There are no CirrOS images for s390x, see lp:1619752.

Validated against our s390x lab