### PR TITLE
Use 'geneve' as private network type for OVN

### DIFF
--- a/tools/2-configure/profiles/s390x-multi-lpar
+++ b/tools/2-configure/profiles/s390x-multi-lpar
@@ -11,7 +11,7 @@
 [[ -z "$CIDR_PRIV" ]] && export CIDR_PRIV="172.16.0.0/12"
 [[ -z "$SWIFT_IP" ]] && export SWIFT_IP="10.245.161.162"  # Cirros image hosted on serverstack
 
-# Accept network type as first parameter, assume gre if unspecified
+# Accept private network type as first parameter, assume gre if unspecified
 net_type=${1:-"gre"}
 
 # Configure neutron networking on the deployed cloud

--- a/tools/2-configure/profiles/s390x-multi-lpar-v3
+++ b/tools/2-configure/profiles/s390x-multi-lpar-v3
@@ -11,8 +11,17 @@
 [[ -z "$CIDR_PRIV" ]] && export CIDR_PRIV="172.16.0.0/12"
 [[ -z "$SWIFT_IP" ]] && export SWIFT_IP="10.245.161.162"  # Cirros image hosted on serverstack
 
-# Accept network type as first parameter, assume gre if unspecified
-net_type=${1:-"gre"}
+juju run --unit ovn-central/leader 'echo This is an OVN setup' 2>/dev/null && is_ovn_setup=true || is_ovn_setup=false
+
+# Accept private network type as first parameter. If unspecified, assume:
+# - 'gre' for an OVS setup,
+# - 'geneve' for an OVN setup.
+if [[ "$is_ovn_setup" == "true" ]]; then
+    default_net_type=geneve
+else
+    default_net_type=gre
+fi
+net_type=${1:-"$default_net_type"}
 
 # Configure neutron networking on overcloud
 source ../../openrcv3_domain

--- a/tools/2-configure/profiles/s390x-zkvm
+++ b/tools/2-configure/profiles/s390x-zkvm
@@ -8,7 +8,7 @@
 [[ -z "$CIDR_PRIV" ]] && export CIDR_PRIV="172.16.0.0/12"
 [[ -z "$SWIFT_IP" ]] && export SWIFT_IP="10.245.161.162"
 
-# Accept network type as first parameter, assume gre if unspecified
+# Accept private network type as first parameter, assume gre if unspecified
 net_type=${1:-"gre"}
 
 # Configure neutron networking on the deployed cloud


### PR DESCRIPTION
OVN doesn't support 'gre' but does support 'geneve'.
OVS doesn't support 'geneve' but does support 'gre'.

Validated against our s390x lab