### PR TITLE
Fix Tempest dashboard tests against HTTPS API

### DIFF
--- a/tools/2-configure/templates/tempest/tempest-v3.conf.template
+++ b/tools/2-configure/templates/tempest/tempest-v3.conf.template
@@ -24,6 +24,8 @@ block_migration_for_live_migration=true
 [dashboard]
 dashboard_url=__PROTO__://__DASHBOARD__/horizon
 login_url=__PROTO__://__DASHBOARD__/horizon/auth/login/
+# NOTE(lourot): we're using self-signed certificates:
+disable_ssl_certificate_validation=true
 
 [identity]
 uri_v3=__PROTO__://__KEYSTONE__:5000/v3


### PR DESCRIPTION
We're using self-signed certificates, so tell Tempest
not to try validating the dashboard's certificate.

Validated against our s390x lab.