### PR TITLE
Work around low disk-space while running tempest

### DIFF
--- a/bundles/lpar/focal-xena-next.yaml
+++ b/bundles/lpar/focal-xena-next.yaml
@@ -338,7 +338,7 @@ services:
     options:
       openstack-origin: *openstack-origin
     to:
-    - lxd:3
+    - lxd:4
   rabbitmq-server:
     annotations:
       gui-x: '500'


### PR DESCRIPTION
In our test environment occasionally the 3rd machine
(hosting a nova-compute unit) would run out of space.
This patch moves the openstack-dashboard unit away
from this machine in order to free up some space.