### PR TITLE
Work around low disk-space while running tempest

### DIFF
--- a/bundles/lpar/focal-xena-ovn-next.yaml
+++ b/bundles/lpar/focal-xena-ovn-next.yaml
@@ -343,7 +343,7 @@ applications:
     options:
       openstack-origin: *openstack-origin
     to:
-    - 'lxd:2'
+    - 'lxd:4'
   rabbitmq-server:
     annotations:
       gui-x: '500'

--- a/bundles/lpar/impish-xena-next.yaml
+++ b/bundles/lpar/impish-xena-next.yaml
@@ -224,7 +224,7 @@ services:
       admin-password: openstack
       worker-multiplier: 0.25
     to:
-    - lxd:3
+    - lxd:0
   mysql:
     annotations:
       gui-x: '0'
@@ -256,7 +256,7 @@ services:
       flat-network-providers: physnet1
       worker-multiplier: 0.25
     to:
-    - lxd:1
+    - lxd:4
   placement-mysql-router:
     charm: cs:~openstack-charmers-next/mysql-router
     options:
@@ -271,7 +271,7 @@ services:
       openstack-origin: *openstack-origin
       worker-multiplier: 0.25
     to:
-    - lxd:2
+    - lxd:4
   neutron-gateway:
     annotations:
       gui-x: '0'
@@ -343,7 +343,7 @@ services:
     options:
       openstack-origin: *openstack-origin
     to:
-    - lxd:4
+    - lxd:0
   rabbitmq-server:
     annotations:
       gui-x: '500'

--- a/bundles/lpar/impish-xena-ovn-next.yaml
+++ b/bundles/lpar/impish-xena-ovn-next.yaml
@@ -343,7 +343,7 @@ applications:
     options:
       openstack-origin: *openstack-origin
     to:
-    - 'lxd:2'
+    - 'lxd:4'
   rabbitmq-server:
     annotations:
       gui-x: '500'


### PR DESCRIPTION
In our test environment occasionally nova-compute units
would run out of space. This patch moves other units
away from these machines in order to free up some space.

Change-Id: I2b3c6351e1c93a7c239e6e028b8c2b36207c455c