### PR TITLE
Fix tempest's default_domain_id

### DIFF
--- a/tools/2-configure/profiles/s390x-multi-lpar-v3
+++ b/tools/2-configure/profiles/s390x-multi-lpar-v3
@@ -73,7 +73,7 @@ keystone=$(juju run --unit ${keystone_unit} "unit-get private-address")
 dashboard=$(juju run --unit ${dashboard_unit} "unit-get private-address")
 ncc=$(juju run --unit ${ncc_unit} "unit-get private-address")
 http=${OS_AUTH_PROTOCOL:-http}
-default_domain_id=$(openstack domain list | awk '/default/ {print $2}')
+default_domain_id=$(openstack domain list | awk '/admin_domain/ {print $2}')
 admin_password=${OS_PASSWORD:-openstack}
 root_ca_file=$OS_CACERT
 # NOTE(lourot): when deploying focal-ussuri-ovn,


### PR DESCRIPTION
Aligning with
https://github.com/openstack-charmers/zaza-openstack-tests/blob/master/zaza/openstack/charm_tests/tempest/utils.py#L312

default_domain_id needs to point to admin_domain,
otherwise tempest will fail as described in
https://bugs.launchpad.net/charm-keystone/+bug/1830076