### PR TITLE
Automate setup of lxd, ceph, do-release-upgrade and juju add-machine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ yakkety/**
 func-results.json
 *tempest.conf
 tools/*/tempest/
+tools/1-deploy/simplestreams

--- a/tools/1-deploy/add-lpars.sh
+++ b/tools/1-deploy/add-lpars.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+SCRIPT_DIR=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+# Use edge until this fix gets available in a release
+# https://github.com/lxc/lxd/issues/10231
+LXD_CHANNEL="latest/edge"
+
 readarray LPARS < ./lpars
 if [[ $LPARS == *"EDIT"* ]] 
         then echo ./lpars must be modified to match your environment
@@ -38,8 +43,12 @@ for lpar in ${LPARS[@]}
                 printf "\rSNAPSHOT OK $lpar\n"
         fi
 done
-if [ "$2" == "ADD" ] 
-        then for lpar in ${LPARS[@]}
-                do juju add-machine ssh:ubuntu@${lpar}
-        done
+
+if [ "$2" == "ADD" ]; then
+  for lpar in ${LPARS[@]}; do
+    scp ${SCRIPT_DIR}/lxd-config.yaml ubuntu@${lpar}:/tmp/lxd-config.yaml
+    ssh ubuntu@${lpar} "sudo snap install --channel ${LXD_CHANNEL} lxd && sudo adduser ubuntu lxd && sudo mkdir -p /mnt/swift/lxd/storage-pools/default"
+    ssh ubuntu@${lpar} "cat /tmp/lxd-config.yaml | sudo lxd init --preseed"
+    juju add-machine ssh:ubuntu@${lpar}
+  done
 fi

--- a/tools/1-deploy/add-lpars.sh
+++ b/tools/1-deploy/add-lpars.sh
@@ -52,13 +52,14 @@ if [ "$2" == "ADD" ]; then
         ssh ubuntu@${lpar} "sudo snap install --channel ${LXD_CHANNEL} lxd && sudo adduser ubuntu lxd && sudo mkdir -p /mnt/swift/lxd/storage-pools/default"
         ssh ubuntu@${lpar} "cat /tmp/lxd-config.yaml | sudo lxd init --preseed"
     fi
+    ssh ubuntu@${lpar} "sudo mkdir -p /mnt/swift/nova/instances"
     juju add-machine ssh:ubuntu@${lpar}
   done
+
+  juju set-model-constraints arch=s390x
+  juju sync-agent-binaries
+
+  MACHINES=$(juju machines --format json | jq -r '.machines|keys| @tsv' | sed 's/\t/,/g')
+  SERIES="$(ssh ubuntu@$LPAR_IP -- lsb_release -c -s)"
+  juju deploy --series $SERIES -n 5 --to $MACHINES --force ch:ubuntu keep
 fi
-
-juju set-model-constraints arch=s390x
-juju sync-agent-binaries
-
-MACHINES=$(juju machines --format json | jq -r '.machines|keys| @tsv' | sed 's/\t/,/g')
-SERIES="$(ssh ubuntu@$LPAR_IP -- lsb_release -c -s)"
-juju deploy --series $SERIES -n 5 --to $MACHINES --force ch:ubuntu keep

--- a/tools/1-deploy/add-lpars.sh
+++ b/tools/1-deploy/add-lpars.sh
@@ -26,7 +26,7 @@ fi
  
 printf "`date` : Waiting for SSH on all LPARS before proceeding...\n\n"
 for lpar in ${LPARS[@]}
-        do ssh-keygen -f "/var/lib/jenkins/.ssh/known_hosts" -R $lpar >/dev/null
+        do ssh-keygen -f "$HOME/.ssh/known_hosts" -R $lpar >/dev/null
 done
 for lpar in ${LPARS[@]}
         do printf "Waiting for $lpar"

--- a/tools/1-deploy/add-lpars.sh
+++ b/tools/1-deploy/add-lpars.sh
@@ -46,9 +46,12 @@ done
 
 if [ "$2" == "ADD" ]; then
   for lpar in ${LPARS[@]}; do
-    scp ${SCRIPT_DIR}/lxd-config.yaml ubuntu@${lpar}:/tmp/lxd-config.yaml
-    ssh ubuntu@${lpar} "sudo snap install --channel ${LXD_CHANNEL} lxd && sudo adduser ubuntu lxd && sudo mkdir -p /mnt/swift/lxd/storage-pools/default"
-    ssh ubuntu@${lpar} "cat /tmp/lxd-config.yaml | sudo lxd init --preseed"
+    LPAR_IP=${lpar}
+    if ! ssh ubuntu@${lpar} "sudo lxc storage info default"; then
+        scp ${SCRIPT_DIR}/lxd-config.yaml ubuntu@${lpar}:/tmp/lxd-config.yaml
+        ssh ubuntu@${lpar} "sudo snap install --channel ${LXD_CHANNEL} lxd && sudo adduser ubuntu lxd && sudo mkdir -p /mnt/swift/lxd/storage-pools/default"
+        ssh ubuntu@${lpar} "cat /tmp/lxd-config.yaml | sudo lxd init --preseed"
+    fi
     juju add-machine ssh:ubuntu@${lpar}
   done
 fi

--- a/tools/1-deploy/add-lpars.sh
+++ b/tools/1-deploy/add-lpars.sh
@@ -55,3 +55,10 @@ if [ "$2" == "ADD" ]; then
     juju add-machine ssh:ubuntu@${lpar}
   done
 fi
+
+juju set-model-constraints arch=s390x
+juju sync-agent-binaries
+
+MACHINES=$(juju machines --format json | jq -r '.machines|keys| @tsv' | sed 's/\t/,/g')
+SERIES="$(ssh ubuntu@$LPAR_IP -- lsb_release -c -s)"
+juju deploy --series $SERIES -n 5 --to $MACHINES --force ch:ubuntu keep

--- a/tools/1-deploy/do-release-upgrade.sh
+++ b/tools/1-deploy/do-release-upgrade.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -eux
+
+readarray LPARS < ./lpars
+for LPAR in ${LPARS[@]}; do
+  # upgrade from focal to jammy needs `-d` until jammy is GA.
+  if [ "x$(ssh ubuntu@${LPAR} -- lsb_release -c -s)" != "xjammy" ]; then
+    if (( $(distro-info --series=jammy --days) > 0 )); then
+      EXTRA_OPTS="-d"
+    else
+      EXTRA_OPTS=""
+    fi
+    ssh ubuntu@${LPAR} "sudo  do-release-upgrade $EXTRA_OPTS -f DistUpgradeViewNonInteractive"
+  fi
+done

--- a/tools/1-deploy/juju-bootstrap-local-build.sh
+++ b/tools/1-deploy/juju-bootstrap-local-build.sh
@@ -1,0 +1,59 @@
+#!/bin/bash -e
+#
+# This program does a juju bootstrap with the manual provider using locally
+# built binaries which are searched in ~/git/juju , it's up to the user to
+# have them already built for amd64 and s390x running the following commands
+# in the juju repo:
+#
+#   $ make build  # build amd64
+#   $ env GOOS=linux GOARCH=s390x make build
+
+CONTROLLER_IP="$1"
+
+if [ -z "$CONTROLLER_IP" ]; then
+  echo "Usage: $0 <controller_ip> [controller_name]"
+  exit 1
+fi
+
+CLOUD_NAME="manual/ubuntu@${CONTROLLER_IP}"
+CONTROLLER_NAME=${2:-juju-controller-s390x}
+SCRIPT_DIR=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
+JUJU_REPO_DIR="$HOME/git/juju"
+JUJU_BRANCH="2.9"
+
+cd $JUJU_REPO_DIR
+git checkout $JUJU_BRANCH
+JUJU_VERSION=$(grep "const version" version/version.go | awk '{print $4}' | tr -d '"')
+echo "Using juju version $JUJU_VERSION"
+if [ ! -d "${JUJU_REPO_DIR}/_build/linux_s390x" ]; then
+  echo "build for s390x not found at ${JUJU_REPO_DIR}/_build/linux_s390x"
+  exit 1
+fi
+
+if [ ! -d "${JUJU_REPO_DIR}/_build/linux_amd64" ]; then
+  echo "build for amd64 not found at ${JUJU_REPO_DIR}/_build/linux_amd64"
+  exit 1
+fi
+
+rm -rf ${SCRIPT_DIR}/simplestreams
+mkdir -p ${SCRIPT_DIR}/simplestreams/tools/released/
+
+cd ${JUJU_REPO_DIR}/_build/linux_s390x/bin
+echo "Creating tarball: juju-${JUJU_VERSION}-ubuntu-s390x.tgz"
+tar czf ${SCRIPT_DIR}/simplestreams/tools/released/juju-${JUJU_VERSION}-ubuntu-s390x.tgz \
+    containeragent juju jujuc jujud juju-metadata juju-wait-for pebble
+echo "Creating tarball: juju-${JUJU_VERSION}-ubuntu-amd64.tgz"
+cd ${JUJU_REPO_DIR}/_build/linux_amd64/bin
+tar czf ${SCRIPT_DIR}/simplestreams/tools/released/juju-${JUJU_VERSION}-ubuntu-amd64.tgz \
+    containeragent juju jujuc jujud juju-metadata juju-wait-for pebble
+
+echo "Running juju metadata generate-agents..."
+juju metadata generate-agents -d ${SCRIPT_DIR}/simplestreams --clean --prevent-fallback
+
+
+ssh-keygen -f "/home/ubuntu/.ssh/known_hosts" -R "${CONTROLLER_IP}"
+ssh-keyscan -t rsa -H ${CONTROLLER_IP} >> $HOME/.ssh/known_hosts
+echo "juju bootstrap..."
+juju bootstrap --agent-version $JUJU_VERSION --no-gui --metadata-source ${SCRIPT_DIR}/simplestreams ${CLOUD_NAME} ${CONTROLLER_NAME}
+echo "juju sync-agent-binaries..."
+juju sync-agent-binaries --source $HOME/simplestreams/tools

--- a/tools/1-deploy/lxd-config.yaml
+++ b/tools/1-deploy/lxd-config.yaml
@@ -1,0 +1,39 @@
+config:
+  core.proxy_ignore_hosts: 10.13.3.14,127.0.0.1,::1,localhost
+networks:
+- config:
+    ipv4.address: 10.174.84.1/24
+    ipv4.nat: "true"
+    ipv6.address: none
+    ipv6.nat: "false"
+  description: ""
+  name: lxdbr0
+  type: bridge
+  project: default
+storage_pools:
+- config:
+    source: /mnt/swift/lxd/storage-pools/default
+  description: ""
+  name: default
+  driver: dir
+profiles:
+- config: {}
+  description: Default LXD profile
+  devices:
+    eth0:
+      nictype: bridged
+      parent: lxdbr0
+      type: nic
+    root:
+      path: /
+      pool: default
+      type: disk
+  name: default
+projects:
+- config:
+    features.images: "true"
+    features.networks: "true"
+    features.profiles: "true"
+    features.storage.volumes: "true"
+  description: Default LXD project
+  name: default

--- a/tools/1-deploy/setup-ceph-osd.sh
+++ b/tools/1-deploy/setup-ceph-osd.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -ex
+
+CEPH_OSD_UNITS="$(juju status --format json ceph-osd | jq -r '.applications."ceph-osd".units|keys|@tsv')"
+
+for UNIT in $CEPH_OSD_UNITS; do
+  # Sometimes $dev is present but not $partition yet and it will make it show
+  # up:
+  SERIES=$(juju ssh $UNIT "lsb_release -s -c" | tr -d '\r')
+
+  # find the disk labeled CEPH
+  for DEV in /dev/dasd{b..z};do
+    if juju ssh $UNIT -- sudo fdasd -i $DEV 2>/dev/null | grep CEPH; then
+      DEVICE=$DEV
+      break
+    fi
+  done
+  if [ -z "$DEVICE" ]; then
+    echo "CEPH device not found"
+    exit 1
+  fi
+  PARTITION="${DEVICE}1"
+
+  if [[ "$SERIES" > "bionic" ]]; then
+    juju run -u $UNIT "sudo fdasd -a $DEVICE -l ceph && sudo partprobe"
+    juju run -u $UNIT "test -e $PARTITION"
+  fi
+
+  juju run-action --wait $UNIT zap-disk devices=$PARTITION i-really-mean-it=true
+  juju run-action --wait $UNIT add-disk osd-devices=$PARTITION
+done


### PR DESCRIPTION
This pull request contains the following changes:

* add-lpars.sh now configures LXD via a preseed file to then run juju add-machine, also the 'keep' application is deployed at the end.
* setup-ceph-osd.sh: looks for the disks set with the CEPH label to run zap-disk and add-disk actions to configure the ceph cluster.
* juju-bootstrap-local-build.sh: script to create a simplestreams index from locally built juju binaries and bootstrap using manual provider.