### PR TITLE
Use charmhub for Yoga bundles.

### DIFF
--- a/bundles/lpar/focal-yoga-next.yaml
+++ b/bundles/lpar/focal-yoga-next.yaml
@@ -130,6 +130,29 @@ relations:
   - swift-storage-z4:swift-storage
 - - swift-proxy:swift-storage
   - swift-storage-z5:swift-storage
+
+# Vault
+- - vault:shared-db
+  - vault-mysql-router:shared-db
+- - vault-mysql-router:db-router
+  - mysql:db-router
+- - neutron-api:certificates
+  - vault:certificates
+- - vault:certificates
+  - cinder:certificates
+- - vault:certificates
+  - glance:certificates
+- - vault:certificates
+  - keystone:certificates
+- - vault:certificates
+  - nova-cloud-controller:certificates
+- - vault:certificates
+  - openstack-dashboard:certificates
+- - vault:certificates
+  - placement:certificates
+- - vault:certificates
+  - swift-proxy:certificates
+
 series: focal
 services:
   ceph-mon:
@@ -372,6 +395,17 @@ services:
     to:
     - lxd:0
     channel: 3.8/edge
+  vault-mysql-router:
+    charm: ch:mysql-router
+    options:
+      source: *openstack-origin
+    channel: 8.0.19/edge
+  vault:
+    charm: ch:vault
+    num_units: 1
+    to:
+    - 'lxd:4'
+    channel: 1.7/edge
   swift-proxy:
     charm: ch:swift-proxy
     num_units: 1

--- a/bundles/lpar/focal-yoga-next.yaml
+++ b/bundles/lpar/focal-yoga-next.yaml
@@ -1,3 +1,5 @@
+local_overlay_enabled: False
+
 variables:
   openstack-origin:    &openstack-origin     cloud:focal-yoga
 machines:
@@ -134,7 +136,7 @@ services:
     annotations:
       gui-x: '750'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/focal/ceph-mon
+    charm: ch:ceph-mon
     num_units: 3
     options:
       expected-osd-count: 3
@@ -143,11 +145,12 @@ services:
     - 'lxd:1'
     - 'lxd:2'
     - 'lxd:3'
+    channel: quincy/edge
   ceph-osd:
     annotations:
       gui-x: '1000'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/focal/ceph-osd
+    charm: ch:ceph-osd
     num_units: 3
     options:
       osd-devices: /dev/sdb
@@ -156,25 +159,28 @@ services:
     - '1'
     - '2'
     - '3'
+    channel: quincy/edge
   ceph-radosgw:
     annotations:
       gui-x: '1000'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/focal/ceph-radosgw
+    charm: ch:ceph-radosgw
     num_units: 1
     options:
       source: *openstack-origin
     to:
     - lxd:0
+    channel: quincy/edge
   cinder-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
     options:
       source: *openstack-origin
+    channel: 8.0.19/edge
   cinder:
     annotations:
       gui-x: '750'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/focal/cinder
+    charm: ch:cinder
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -183,36 +189,41 @@ services:
       worker-multiplier: 0.25
     to:
     - lxd:1
+    channel: yoga/edge
   cinder-ceph:
     annotations:
       gui-x: '750'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/focal/cinder-ceph
+    charm: ch:cinder-ceph
     num_units: 0
+    channel: yoga/edge
   glance-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
     options:
       source: *openstack-origin
+    channel: 8.0.19/edge
   glance:
     annotations:
       gui-x: '250'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/focal/glance
+    charm: ch:glance
     num_units: 1
     options:
       openstack-origin: *openstack-origin
       worker-multiplier: 0.25
     to:
     - lxd:2
+    channel: yoga/edge
   keystone-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
     options:
       source: *openstack-origin
+    channel: 8.0.19/edge
   keystone:
     annotations:
       gui-x: '500'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/focal/keystone
+    charm: ch:keystone
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -220,11 +231,12 @@ services:
       worker-multiplier: 0.25
     to:
     - lxd:3
+    channel: yoga/edge
   mysql:
     annotations:
       gui-x: '0'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/mysql-innodb-cluster
+    charm: ch:mysql-innodb-cluster
     num_units: 3
     options:
       max-connections: 1000
@@ -234,15 +246,17 @@ services:
     - lxd:0
     - lxd:3
     - lxd:4
+    channel: 8.0.19/edge
   neutron-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
     options:
       source: *openstack-origin
+    channel: 8.0.19/edge
   neutron-api:
     annotations:
       gui-x: '500'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/focal/neutron-api
+    charm: ch:neutron-api
     num_units: 1
     options:
       manage-neutron-plugin-legacy-mode: true
@@ -252,26 +266,29 @@ services:
       worker-multiplier: 0.25
     to:
     - lxd:1
+    channel: yoga/edge
   placement-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
     options:
       source: *openstack-origin
+    channel: 8.0.19/edge
   placement:
     annotations:
       gui-x: '0'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/focal/placement
+    charm: ch:placement
     num_units: 1
     options:
       openstack-origin: *openstack-origin
       worker-multiplier: 0.25
     to:
     - lxd:2
+    channel: yoga/edge
   neutron-gateway:
     annotations:
       gui-x: '0'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/focal/neutron-gateway
+    charm: ch:neutron-gateway
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -280,21 +297,24 @@ services:
       worker-multiplier: 0.25
     to:
     - '0'
+    channel: yoga/edge
   neutron-openvswitch:
     annotations:
       gui-x: '250'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/neutron-openvswitch
+    charm: ch:neutron-openvswitch
     num_units: 0
+    channel: yoga/edge
   nova-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
     options:
       source: *openstack-origin
+    channel: 8.0.19/edge
   nova-cloud-controller:
     annotations:
       gui-x: '0'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/focal/nova-cloud-controller
+    charm: ch:nova-cloud-controller
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -302,11 +322,12 @@ services:
       worker-multiplier: 0.25
     to:
     - lxd:2
+    channel: yoga/edge
   nova-compute:
     annotations:
       gui-x: '250'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/focal/nova-compute
+    charm: ch:nova-compute
     num_units: 3
     options:
       config-flags: default_ephemeral_format=ext4
@@ -318,37 +339,41 @@ services:
     - '1'
     - '2'
     - '3'
+    channel: yoga/edge
   ntp:
     series: bionic
     annotations:
       gui-x: '1000'
       gui-y: '0'
-    charm: cs:ntp
+    charm: ch:ntp
     num_units: 0
   dashboard-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
     options:
       source: *openstack-origin
+    channel: 8.0.19/edge
   openstack-dashboard:
     annotations:
       gui-x: '500'
       gui-y: '-250'
-    charm: cs:~openstack-charmers-next/focal/openstack-dashboard
+    charm: ch:openstack-dashboard
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     to:
     - lxd:4
+    channel: yoga/edge
   rabbitmq-server:
     annotations:
       gui-x: '500'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/focal/rabbitmq-server
+    charm: ch:rabbitmq-server
     num_units: 1
     to:
     - lxd:0
+    channel: 3.8/edge
   swift-proxy:
-    charm: cs:~openstack-charmers-next/swift-proxy
+    charm: ch:swift-proxy
     num_units: 1
     options:
       zone-assignment: manual
@@ -357,8 +382,9 @@ services:
       openstack-origin: *openstack-origin
     to:
       - "lxd:0"
+    channel: yoga/edge
   swift-storage-z1:
-    charm: cs:~openstack-charmers-next/swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       zone: 1
@@ -367,8 +393,9 @@ services:
       openstack-origin: *openstack-origin
     to:
     - '0'
+    channel: yoga/edge
   swift-storage-z2:
-    charm: cs:~openstack-charmers-next/swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       zone: 2
@@ -377,8 +404,9 @@ services:
       openstack-origin: *openstack-origin
     to:
     - '1'
+    channel: yoga/edge
   swift-storage-z3:
-    charm: cs:~openstack-charmers-next/swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       zone: 3
@@ -387,8 +415,9 @@ services:
       openstack-origin: *openstack-origin
     to:
     - '2'
+    channel: yoga/edge
   swift-storage-z4:
-    charm: cs:~openstack-charmers-next/swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       zone: 4
@@ -397,8 +426,9 @@ services:
       openstack-origin: *openstack-origin
     to:
     - '3'
+    channel: yoga/edge
   swift-storage-z5:
-    charm: cs:~openstack-charmers-next/swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       zone: 5
@@ -407,3 +437,4 @@ services:
       openstack-origin: *openstack-origin
     to:
     - '4'
+    channel: yoga/edge

--- a/bundles/lpar/focal-yoga-ovn-next.yaml
+++ b/bundles/lpar/focal-yoga-ovn-next.yaml
@@ -6,7 +6,7 @@
 #       section of the [OpenStack Charms Deployment Guide](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/)
 #       for more information.
 ---
-local_overlay_enabled: true
+local_overlay_enabled: False
 series: focal
 variables:
   openstack-origin:    &openstack-origin     cloud:focal-yoga
@@ -169,7 +169,7 @@ applications:
     annotations:
       gui-x: '750'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/ceph-mon
+    charm: ch:ceph-mon
     num_units: 3
     options:
       expected-osd-count: *expected-osd-count
@@ -179,11 +179,12 @@ applications:
     - 'lxd:0'
     - 'lxd:1'
     - 'lxd:2'
+    channel: quincy/edge
   ceph-osd:
     annotations:
       gui-x: '1000'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/ceph-osd
+    charm: ch:ceph-osd
     num_units: 3
     options:
       osd-devices: *osd-devices
@@ -192,25 +193,28 @@ applications:
     - '0'
     - '1'
     - '2'
+    channel: quincy/edge
   ceph-radosgw:
     annotations:
       gui-x: '1000'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/ceph-radosgw
+    charm: ch:ceph-radosgw
     num_units: 1
     options:
       source: *openstack-origin
     to:
     - 'lxd:3'
+    channel: quincy/edge
   cinder-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
     options:
       source: *openstack-origin
+    channel: 8.0.19/edge
   cinder:
     annotations:
       gui-x: '750'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/cinder
+    charm: ch:cinder
     num_units: 1
     options:
       block-device: None
@@ -219,51 +223,58 @@ applications:
       openstack-origin: *openstack-origin
     to:
     - 'lxd:3'
+    channel: yoga/edge
   cinder-ceph:
     annotations:
       gui-x: '750'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/cinder-ceph
+    charm: ch:cinder-ceph
     num_units: 0
+    channel: yoga/edge
   glance-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
     options:
       source: *openstack-origin
+    channel: 8.0.19/edge
   glance:
     annotations:
       gui-x: '250'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/glance
+    charm: ch:glance
     num_units: 1
     options:
       worker-multiplier: *worker-multiplier
       openstack-origin: *openstack-origin
     to:
     - 'lxd:4'
+    channel: yoga/edge
   keystone-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
     options:
       source: *openstack-origin
+    channel: 8.0.19/edge
   keystone:
     annotations:
       gui-x: '500'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/keystone
+    charm: ch:keystone
     num_units: 1
     options:
       worker-multiplier: *worker-multiplier
       openstack-origin: *openstack-origin
     to:
     - 'lxd:3'
+    channel: yoga/edge
   neutron-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
     options:
       source: *openstack-origin
+    channel: 8.0.19/edge
   neutron-api:
     annotations:
       gui-x: '500'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/neutron-api
+    charm: ch:neutron-api
     num_units: 1
     options:
       # NOTE(fnordahl): At current state of upstream Neutron development this
@@ -276,30 +287,34 @@ applications:
       manage-neutron-plugin-legacy-mode: false
     to:
     - 'lxd:4'
+    channel: yoga/edge
   placement-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
     options:
       source: *openstack-origin
+    channel: 8.0.19/edge
   placement:
     annotations:
       gui-x: '0'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/placement
+    charm: ch:placement
     num_units: 1
     options:
       worker-multiplier: *worker-multiplier
       openstack-origin: *openstack-origin
     to:
     - 'lxd:0'
+    channel: yoga/edge
   nova-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
     options:
       source: *openstack-origin
+    channel: 8.0.19/edge
   nova-cloud-controller:
     annotations:
       gui-x: '0'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/nova-cloud-controller
+    charm: ch:nova-cloud-controller
     num_units: 1
     options:
       network-manager: Neutron
@@ -307,11 +322,12 @@ applications:
       openstack-origin: *openstack-origin
     to:
     - 'lxd:1'
+    channel: yoga/edge
   nova-compute:
     annotations:
       gui-x: '250'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/nova-compute
+    charm: ch:nova-compute
     num_units: 3
     options:
       config-flags: default_ephemeral_format=ext4
@@ -323,37 +339,41 @@ applications:
     - '0'
     - '1'
     - '2'
+    channel: yoga/edge
   ntp:
     series: bionic
     annotations:
       gui-x: '1000'
       gui-y: '0'
-    charm: cs:ntp
+    charm: ch:ntp
     num_units: 0
   dashboard-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
     options:
       source: *openstack-origin
+    channel: 8.0.19/edge
   openstack-dashboard:
     annotations:
       gui-x: '500'
       gui-y: '-250'
-    charm: cs:~openstack-charmers-next/openstack-dashboard
+    charm: ch:openstack-dashboard
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     to:
     - 'lxd:4'
+    channel: yoga/edge
   rabbitmq-server:
     annotations:
       gui-x: '500'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/rabbitmq-server
+    charm: ch:rabbitmq-server
     num_units: 1
     to:
     - 'lxd:3'
+    channel: 3.8/edge
   mysql-innodb-cluster:
-    charm: cs:~openstack-charmers-next/mysql-innodb-cluster
+    charm: ch:mysql-innodb-cluster
     num_units: 3
     options:
       max-connections: 1000
@@ -363,10 +383,12 @@ applications:
     - 'lxd:0'
     - 'lxd:1'
     - 'lxd:2'
+    channel: 8.0.19/edge
   neutron-api-plugin-ovn:
-    charm: cs:~openstack-charmers-next/neutron-api-plugin-ovn
+    charm: ch:neutron-api-plugin-ovn
+    channel: yoga/edge
   ovn-central:
-    charm: cs:~openstack-charmers-next/ovn-central
+    charm: ch:ovn-central
     num_units: 3
     options:
       source: *openstack-origin
@@ -374,8 +396,9 @@ applications:
     - 'lxd:0'
     - 'lxd:1'
     - 'lxd:2'
+    channel: 22.03/edge
   ovn-chassis:
-    charm: cs:~openstack-charmers-next/ovn-chassis
+    charm: ch:ovn-chassis
     comment: |
       Please update the `bridge-interface-mappings` to values suitable for the
       hardware used in your deployment.  See the referenced documentation at
@@ -383,17 +406,20 @@ applications:
     options:
       ovn-bridge-mappings: physnet1:br-ex
       bridge-interface-mappings: *data-port
+    channel: 22.03/edge
   vault-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
     options:
       source: *openstack-origin
+    channel: 8.0.19/edge
   vault:
-    charm: cs:~openstack-charmers-next/vault
+    charm: ch:vault
     num_units: 1
     to:
     - 'lxd:4'
+    channel: 1.7/edge
   swift-proxy:
-    charm: cs:~openstack-charmers-next/swift-proxy
+    charm: ch:swift-proxy
     num_units: 1
     options:
       zone-assignment: manual
@@ -402,8 +428,9 @@ applications:
       openstack-origin: *openstack-origin
     to:
       - "lxd:0"
+    channel: yoga/edge
   swift-storage-z1:
-    charm: cs:~openstack-charmers-next/swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       zone: 1
@@ -412,8 +439,9 @@ applications:
       openstack-origin: *openstack-origin
     to:
     - '0'
+    channel: yoga/edge
   swift-storage-z2:
-    charm: cs:~openstack-charmers-next/swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       zone: 2
@@ -422,8 +450,9 @@ applications:
       openstack-origin: *openstack-origin
     to:
     - '1'
+    channel: yoga/edge
   swift-storage-z3:
-    charm: cs:~openstack-charmers-next/swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       zone: 3
@@ -432,8 +461,9 @@ applications:
       openstack-origin: *openstack-origin
     to:
     - '2'
+    channel: yoga/edge
   swift-storage-z4:
-    charm: cs:~openstack-charmers-next/swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       zone: 4
@@ -442,8 +472,9 @@ applications:
       openstack-origin: *openstack-origin
     to:
     - '3'
+    channel: yoga/edge
   swift-storage-z5:
-    charm: cs:~openstack-charmers-next/swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       zone: 5
@@ -452,3 +483,4 @@ applications:
       openstack-origin: *openstack-origin
     to:
     - '4'
+    channel: yoga/edge

--- a/bundles/lpar/jammy-yoga-next.yaml
+++ b/bundles/lpar/jammy-yoga-next.yaml
@@ -1,3 +1,5 @@
+local_overlay_enabled: False
+
 variables:
   openstack-origin:    &openstack-origin     distro
 machines:
@@ -134,7 +136,7 @@ services:
     annotations:
       gui-x: '750'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/ceph-mon
+    charm: ch:ceph-mon
     num_units: 3
     options:
       expected-osd-count: 3
@@ -147,11 +149,12 @@ services:
     - 'lxd:1'
     - 'lxd:2'
     - 'lxd:3'
+    channel: quincy/edge
   ceph-osd:
     annotations:
       gui-x: '1000'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/ceph-osd
+    charm: ch:ceph-osd
     num_units: 3
     options:
       osd-devices: /dev/sdb
@@ -160,25 +163,28 @@ services:
     - '1'
     - '2'
     - '3'
+    channel: quincy/edge
   ceph-radosgw:
     annotations:
       gui-x: '1000'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/ceph-radosgw
+    charm: ch:ceph-radosgw
     num_units: 1
     options:
       source: *openstack-origin
     to:
     - lxd:0
+    channel: quincy/edge
   cinder-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
     options:
       source: *openstack-origin
+    channel: 8.0.19/edge
   cinder:
     annotations:
       gui-x: '750'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/cinder
+    charm: ch:cinder
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -187,36 +193,41 @@ services:
       worker-multiplier: 0.25
     to:
     - lxd:1
+    channel: yoga/edge
   cinder-ceph:
     annotations:
       gui-x: '750'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/cinder-ceph
+    charm: ch:cinder-ceph
     num_units: 0
+    channel: yoga/edge
   glance-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
     options:
       source: *openstack-origin
+    channel: 8.0.19/edge
   glance:
     annotations:
       gui-x: '250'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/glance
+    charm: ch:glance
     num_units: 1
     options:
       openstack-origin: *openstack-origin
       worker-multiplier: 0.25
     to:
     - lxd:0
+    channel: yoga/edge
   keystone-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
     options:
       source: *openstack-origin
+    channel: 8.0.19/edge
   keystone:
     annotations:
       gui-x: '500'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/keystone
+    charm: ch:keystone
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -224,11 +235,12 @@ services:
       worker-multiplier: 0.25
     to:
     - lxd:0
+    channel: yoga/edge
   mysql:
     annotations:
       gui-x: '0'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/mysql-innodb-cluster
+    charm: ch:mysql-innodb-cluster
     num_units: 3
     options:
       max-connections: 1000
@@ -238,15 +250,17 @@ services:
     - lxd:0
     - lxd:3
     - lxd:4
+    channel: 8.0.19/edge
   neutron-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
     options:
       source: *openstack-origin
+    channel: 8.0.19/edge
   neutron-api:
     annotations:
       gui-x: '500'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/neutron-api
+    charm: ch:neutron-api
     num_units: 1
     options:
       manage-neutron-plugin-legacy-mode: true
@@ -256,26 +270,29 @@ services:
       worker-multiplier: 0.25
     to:
     - lxd:4
+    channel: yoga/edge
   placement-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
     options:
       source: *openstack-origin
+    channel: 8.0.19/edge
   placement:
     annotations:
       gui-x: '0'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/placement
+    charm: ch:placement
     num_units: 1
     options:
       openstack-origin: *openstack-origin
       worker-multiplier: 0.25
     to:
     - lxd:4
+    channel: yoga/edge
   neutron-gateway:
     annotations:
       gui-x: '0'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/neutron-gateway
+    charm: ch:neutron-gateway
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -284,21 +301,24 @@ services:
       worker-multiplier: 0.25
     to:
     - '0'
+    channel: yoga/edge
   neutron-openvswitch:
     annotations:
       gui-x: '250'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/neutron-openvswitch
+    charm: ch:neutron-openvswitch
     num_units: 0
+    channel: yoga/edge
   nova-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
     options:
       source: *openstack-origin
+    channel: 8.0.19/edge
   nova-cloud-controller:
     annotations:
       gui-x: '0'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/nova-cloud-controller
+    charm: ch:nova-cloud-controller
     num_units: 1
     options:
       openstack-origin: *openstack-origin
@@ -306,11 +326,12 @@ services:
       worker-multiplier: 0.25
     to:
     - lxd:2
+    channel: yoga/edge
   nova-compute:
     annotations:
       gui-x: '250'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/nova-compute
+    charm: ch:nova-compute
     num_units: 3
     options:
       config-flags: default_ephemeral_format=ext4
@@ -322,37 +343,41 @@ services:
     - '1'
     - '2'
     - '3'
+    channel: yoga/edge
   ntp:
     series: bionic
     annotations:
       gui-x: '1000'
       gui-y: '0'
-    charm: cs:ntp
+    charm: ch:ntp
     num_units: 0
   dashboard-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
     options:
       source: *openstack-origin
+    channel: 8.0.19/edge
   openstack-dashboard:
     annotations:
       gui-x: '500'
       gui-y: '-250'
-    charm: cs:~openstack-charmers-next/openstack-dashboard
+    charm: ch:openstack-dashboard
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     to:
     - lxd:0
+    channel: yoga/edge
   rabbitmq-server:
     annotations:
       gui-x: '500'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/rabbitmq-server
+    charm: ch:rabbitmq-server
     num_units: 1
     to:
     - lxd:0
+    channel: 3.9/edge
   swift-proxy:
-    charm: cs:~openstack-charmers-next/swift-proxy
+    charm: ch:swift-proxy
     num_units: 1
     options:
       zone-assignment: manual
@@ -361,8 +386,9 @@ services:
       openstack-origin: *openstack-origin
     to:
       - "lxd:0"
+    channel: yoga/edge
   swift-storage-z1:
-    charm: cs:~openstack-charmers-next/swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       zone: 1
@@ -371,8 +397,9 @@ services:
       openstack-origin: *openstack-origin
     to:
     - '0'
+    channel: yoga/edge
   swift-storage-z2:
-    charm: cs:~openstack-charmers-next/swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       zone: 2
@@ -381,8 +408,9 @@ services:
       openstack-origin: *openstack-origin
     to:
     - '1'
+    channel: yoga/edge
   swift-storage-z3:
-    charm: cs:~openstack-charmers-next/swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       zone: 3
@@ -391,8 +419,9 @@ services:
       openstack-origin: *openstack-origin
     to:
     - '2'
+    channel: yoga/edge
   swift-storage-z4:
-    charm: cs:~openstack-charmers-next/swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       zone: 4
@@ -401,8 +430,9 @@ services:
       openstack-origin: *openstack-origin
     to:
     - '3'
+    channel: yoga/edge
   swift-storage-z5:
-    charm: cs:~openstack-charmers-next/swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       zone: 5
@@ -411,3 +441,4 @@ services:
       openstack-origin: *openstack-origin
     to:
     - '4'
+    channel: yoga/edge

--- a/bundles/lpar/jammy-yoga-next.yaml
+++ b/bundles/lpar/jammy-yoga-next.yaml
@@ -130,6 +130,29 @@ relations:
   - swift-storage-z4:swift-storage
 - - swift-proxy:swift-storage
   - swift-storage-z5:swift-storage
+
+# Vault
+- - vault:shared-db
+  - vault-mysql-router:shared-db
+- - vault-mysql-router:db-router
+  - mysql:db-router
+- - neutron-api:certificates
+  - vault:certificates
+- - vault:certificates
+  - cinder:certificates
+- - vault:certificates
+  - glance:certificates
+- - vault:certificates
+  - keystone:certificates
+- - vault:certificates
+  - nova-cloud-controller:certificates
+- - vault:certificates
+  - openstack-dashboard:certificates
+- - vault:certificates
+  - placement:certificates
+- - vault:certificates
+  - swift-proxy:certificates
+
 series: jammy
 services:
   ceph-mon:
@@ -376,6 +399,17 @@ services:
     to:
     - lxd:0
     channel: 3.9/edge
+  vault-mysql-router:
+    charm: ch:mysql-router
+    options:
+      source: *openstack-origin
+    channel: 8.0.19/edge
+  vault:
+    charm: ch:vault
+    num_units: 1
+    to:
+    - 'lxd:4'
+    channel: 1.7/edge
   swift-proxy:
     charm: ch:swift-proxy
     num_units: 1

--- a/bundles/lpar/jammy-yoga-next.yaml
+++ b/bundles/lpar/jammy-yoga-next.yaml
@@ -108,10 +108,6 @@ relations:
   - glance:ceph
 - - ceph-osd:mon
   - ceph-mon:osd
-- - ntp:juju-info
-  - nova-compute:juju-info
-- - ntp:juju-info
-  - neutron-gateway:juju-info
 - - ceph-radosgw:mon
   - ceph-mon:radosgw
 - - ceph-radosgw:identity-service
@@ -367,13 +363,6 @@ services:
     - '2'
     - '3'
     channel: yoga/edge
-  ntp:
-    series: bionic
-    annotations:
-      gui-x: '1000'
-      gui-y: '0'
-    charm: ch:ntp
-    num_units: 0
   dashboard-mysql-router:
     charm: ch:mysql-router
     options:

--- a/bundles/lpar/jammy-yoga-ovn-next.yaml
+++ b/bundles/lpar/jammy-yoga-ovn-next.yaml
@@ -6,7 +6,7 @@
 #       section of the [OpenStack Charms Deployment Guide](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/)
 #       for more information.
 ---
-local_overlay_enabled: true
+local_overlay_enabled: False
 series: jammy
 variables:
   openstack-origin:    &openstack-origin     distro
@@ -169,7 +169,7 @@ applications:
     annotations:
       gui-x: '750'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/ceph-mon
+    charm: ch:ceph-mon
     num_units: 3
     options:
       expected-osd-count: *expected-osd-count
@@ -179,11 +179,12 @@ applications:
     - 'lxd:0'
     - 'lxd:1'
     - 'lxd:2'
+    channel: quincy/edge
   ceph-osd:
     annotations:
       gui-x: '1000'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/ceph-osd
+    charm: ch:ceph-osd
     num_units: 3
     options:
       osd-devices: *osd-devices
@@ -192,25 +193,28 @@ applications:
     - '0'
     - '1'
     - '2'
+    channel: quincy/edge
   ceph-radosgw:
     annotations:
       gui-x: '1000'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/ceph-radosgw
+    charm: ch:ceph-radosgw
     num_units: 1
     options:
       source: *openstack-origin
     to:
     - 'lxd:3'
+    channel: quincy/edge
   cinder-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
     options:
       source: *openstack-origin
+    channel: 8.0.19/edge
   cinder:
     annotations:
       gui-x: '750'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/cinder
+    charm: ch:cinder
     num_units: 1
     options:
       block-device: None
@@ -219,51 +223,58 @@ applications:
       openstack-origin: *openstack-origin
     to:
     - 'lxd:3'
+    channel: yoga/edge
   cinder-ceph:
     annotations:
       gui-x: '750'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/cinder-ceph
+    charm: ch:cinder-ceph
     num_units: 0
+    channel: yoga/edge
   glance-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
     options:
       source: *openstack-origin
+    channel: 8.0.19/edge
   glance:
     annotations:
       gui-x: '250'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/glance
+    charm: ch:glance
     num_units: 1
     options:
       worker-multiplier: *worker-multiplier
       openstack-origin: *openstack-origin
     to:
     - 'lxd:4'
+    channel: yoga/edge
   keystone-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
     options:
       source: *openstack-origin
+    channel: 8.0.19/edge
   keystone:
     annotations:
       gui-x: '500'
       gui-y: '0'
-    charm: cs:~openstack-charmers-next/keystone
+    charm: ch:keystone
     num_units: 1
     options:
       worker-multiplier: *worker-multiplier
       openstack-origin: *openstack-origin
     to:
     - 'lxd:3'
+    channel: yoga/edge
   neutron-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
     options:
       source: *openstack-origin
+    channel: 8.0.19/edge
   neutron-api:
     annotations:
       gui-x: '500'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/neutron-api
+    charm: ch:neutron-api
     num_units: 1
     options:
       # NOTE(fnordahl): At current state of upstream Neutron development this
@@ -276,30 +287,34 @@ applications:
       manage-neutron-plugin-legacy-mode: false
     to:
     - 'lxd:4'
+    channel: yoga/edge
   placement-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
     options:
       source: *openstack-origin
+    channel: 8.0.19/edge
   placement:
     annotations:
       gui-x: '0'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/placement
+    charm: ch:placement
     num_units: 1
     options:
       worker-multiplier: *worker-multiplier
       openstack-origin: *openstack-origin
     to:
     - 'lxd:0'
+    channel: yoga/edge
   nova-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
     options:
       source: *openstack-origin
+    channel: 8.0.19/edge
   nova-cloud-controller:
     annotations:
       gui-x: '0'
       gui-y: '500'
-    charm: cs:~openstack-charmers-next/nova-cloud-controller
+    charm: ch:nova-cloud-controller
     num_units: 1
     options:
       network-manager: Neutron
@@ -307,11 +322,12 @@ applications:
       openstack-origin: *openstack-origin
     to:
     - 'lxd:1'
+    channel: yoga/edge
   nova-compute:
     annotations:
       gui-x: '250'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/nova-compute
+    charm: ch:nova-compute
     num_units: 3
     options:
       config-flags: default_ephemeral_format=ext4
@@ -323,37 +339,41 @@ applications:
     - '0'
     - '1'
     - '2'
+    channel: yoga/edge
   ntp:
     series: bionic
     annotations:
       gui-x: '1000'
       gui-y: '0'
-    charm: cs:ntp
+    charm: ch:ntp
     num_units: 0
   dashboard-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
     options:
       source: *openstack-origin
+    channel: 8.0.19/edge
   openstack-dashboard:
     annotations:
       gui-x: '500'
       gui-y: '-250'
-    charm: cs:~openstack-charmers-next/openstack-dashboard
+    charm: ch:openstack-dashboard
     num_units: 1
     options:
       openstack-origin: *openstack-origin
     to:
     - 'lxd:4'
+    channel: yoga/edge
   rabbitmq-server:
     annotations:
       gui-x: '500'
       gui-y: '250'
-    charm: cs:~openstack-charmers-next/rabbitmq-server
+    charm: ch:rabbitmq-server
     num_units: 1
     to:
     - 'lxd:3'
+    channel: 3.9/edge
   mysql-innodb-cluster:
-    charm: cs:~openstack-charmers-next/mysql-innodb-cluster
+    charm: ch:mysql-innodb-cluster
     num_units: 3
     options:
       max-connections: 1000
@@ -363,10 +383,12 @@ applications:
     - 'lxd:0'
     - 'lxd:1'
     - 'lxd:2'
+    channel: 8.0.19/edge
   neutron-api-plugin-ovn:
-    charm: cs:~openstack-charmers-next/neutron-api-plugin-ovn
+    charm: ch:neutron-api-plugin-ovn
+    channel: yoga/edge
   ovn-central:
-    charm: cs:~openstack-charmers-next/ovn-central
+    charm: ch:ovn-central
     num_units: 3
     options:
       source: *openstack-origin
@@ -374,8 +396,9 @@ applications:
     - 'lxd:0'
     - 'lxd:1'
     - 'lxd:2'
+    channel: 22.03/edge
   ovn-chassis:
-    charm: cs:~openstack-charmers-next/ovn-chassis
+    charm: ch:ovn-chassis
     comment: |
       Please update the `bridge-interface-mappings` to values suitable for the
       hardware used in your deployment.  See the referenced documentation at
@@ -383,17 +406,20 @@ applications:
     options:
       ovn-bridge-mappings: physnet1:br-ex
       bridge-interface-mappings: *data-port
+    channel: 22.03/edge
   vault-mysql-router:
-    charm: cs:~openstack-charmers-next/mysql-router
+    charm: ch:mysql-router
     options:
       source: *openstack-origin
+    channel: 8.0.19/edge
   vault:
-    charm: cs:~openstack-charmers-next/vault
+    charm: ch:vault
     num_units: 1
     to:
     - 'lxd:4'
+    channel: 1.7/edge
   swift-proxy:
-    charm: cs:~openstack-charmers-next/swift-proxy
+    charm: ch:swift-proxy
     num_units: 1
     options:
       zone-assignment: manual
@@ -402,8 +428,9 @@ applications:
       openstack-origin: *openstack-origin
     to:
       - "lxd:0"
+    channel: yoga/edge
   swift-storage-z1:
-    charm: cs:~openstack-charmers-next/swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       zone: 1
@@ -412,8 +439,9 @@ applications:
       openstack-origin: *openstack-origin
     to:
     - '0'
+    channel: yoga/edge
   swift-storage-z2:
-    charm: cs:~openstack-charmers-next/swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       zone: 2
@@ -422,8 +450,9 @@ applications:
       openstack-origin: *openstack-origin
     to:
     - '1'
+    channel: yoga/edge
   swift-storage-z3:
-    charm: cs:~openstack-charmers-next/swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       zone: 3
@@ -432,8 +461,9 @@ applications:
       openstack-origin: *openstack-origin
     to:
     - '2'
+    channel: yoga/edge
   swift-storage-z4:
-    charm: cs:~openstack-charmers-next/swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       zone: 4
@@ -442,8 +472,9 @@ applications:
       openstack-origin: *openstack-origin
     to:
     - '3'
+    channel: yoga/edge
   swift-storage-z5:
-    charm: cs:~openstack-charmers-next/swift-storage
+    charm: ch:swift-storage
     num_units: 1
     options:
       zone: 5
@@ -452,3 +483,4 @@ applications:
       openstack-origin: *openstack-origin
     to:
     - '4'
+    channel: yoga/edge

--- a/bundles/lpar/jammy-yoga-ovn-next.yaml
+++ b/bundles/lpar/jammy-yoga-ovn-next.yaml
@@ -109,8 +109,6 @@ relations:
   - glance:ceph
 - - ceph-osd:mon
   - ceph-mon:osd
-- - ntp:juju-info
-  - nova-compute:juju-info
 - - ceph-radosgw:mon
   - ceph-mon:radosgw
 - - ceph-radosgw:identity-service
@@ -340,13 +338,6 @@ applications:
     - '1'
     - '2'
     channel: yoga/edge
-  ntp:
-    series: bionic
-    annotations:
-      gui-x: '1000'
-      gui-y: '0'
-    charm: ch:ntp
-    num_units: 0
   dashboard-mysql-router:
     charm: ch:mysql-router
     options:


### PR DESCRIPTION
This PR includes the following changes to make the OpenStack Yoga bundles deployable.

* Switch from `cs:` prefix to `ch:` with appropriate channels (edge risk level) for each charm.
* Add vault charm.
* Remove ntp charm from jammy bundles.