### PR TITLE
do-release-upgrade.sh improvements.

### DIFF
--- a/tools/1-deploy/do-release-upgrade.sh
+++ b/tools/1-deploy/do-release-upgrade.sh
@@ -6,7 +6,11 @@ for LPAR in ${LPARS[@]}; do
   ssh-keyscan -t rsa -H ${LPAR} >> $HOME/.ssh/known_hosts
   # upgrade from focal to jammy needs `-d` until jammy is GA.
   if [ "x$(ssh ubuntu@${LPAR} -- lsb_release -c -s)" != "xjammy" ]; then
-    if (( $(distro-info --series=jammy --days) > 0 )); then
+    # The -d flag is needed not until the LTS version is released, instead
+    # until the first point release of the LTS is released, that milestone is
+    # reflected on the meta-release-lts file which is consumed by
+    # do-release-upgrade to determine if there is a new version available.
+    if ! curl -s "http://changelogs.ubuntu.com/meta-release-lts" | grep -q "Dist: jammy"; then
       EXTRA_OPTS="-d"
     else
       EXTRA_OPTS=""

--- a/tools/1-deploy/do-release-upgrade.sh
+++ b/tools/1-deploy/do-release-upgrade.sh
@@ -9,6 +9,7 @@ for LPAR in ${LPARS[@]}; do
     else
       EXTRA_OPTS=""
     fi
-    ssh ubuntu@${LPAR} "sudo  do-release-upgrade $EXTRA_OPTS -f DistUpgradeViewNonInteractive"
+    ssh ubuntu@${LPAR} "sudo do-release-upgrade $EXTRA_OPTS -f DistUpgradeViewNonInteractive"
+    ssh ubuntu@${LPAR} "sudo reboot" || echo "Rebooting ${LPAR}..."
   fi
 done

--- a/tools/1-deploy/do-release-upgrade.sh
+++ b/tools/1-deploy/do-release-upgrade.sh
@@ -2,6 +2,8 @@
 
 readarray LPARS < ./lpars
 for LPAR in ${LPARS[@]}; do
+  ssh-keygen -f "${HOME}/.ssh/known_hosts" -R "${LPAR}"
+  ssh-keyscan -t rsa -H ${LPAR} >> $HOME/.ssh/known_hosts
   # upgrade from focal to jammy needs `-d` until jammy is GA.
   if [ "x$(ssh ubuntu@${LPAR} -- lsb_release -c -s)" != "xjammy" ]; then
     if (( $(distro-info --series=jammy --days) > 0 )); then


### PR DESCRIPTION
Improvements to make the do-release-upgrade.sh script more are robust are:

* Refresh the SSH host keys for each lpar.
* Check http://changelogs.ubuntu.com/meta-release-lts to determine if `-d` is needed instead of `distro-info`.
* Reboot the host (lpar) after do-release-upgrade has completed the upgrade process successfully to boot into the new kernel.