### PR TITLE
Add zaza configuration to initialize vault.

### DIFF
--- a/initialize_vault/test-requirements.txt
+++ b/initialize_vault/test-requirements.txt
@@ -1,0 +1,3 @@
+# zaza
+git+https://github.com/openstack-charmers/zaza.git#egg=zaza
+git+https://github.com/openstack-charmers/zaza-openstack-tests.git#egg=zaza.openstack

--- a/initialize_vault/tests/tests.yaml
+++ b/initialize_vault/tests/tests.yaml
@@ -1,0 +1,10 @@
+configure:
+ - zaza.openstack.charm_tests.vault.setup.auto_initialize_no_validation
+
+target_deploy_status:
+  ntp:
+    workload-status: active
+    workload-status-message: "chrony: Ready"
+  keep:
+    workload-status: active
+    workload-status-message: ""

--- a/initialize_vault/tox.ini
+++ b/initialize_vault/tox.ini
@@ -1,0 +1,30 @@
+[tox]
+envlist = pep8
+skipsdist = True
+# NOTES:
+# * We avoid the new dependency resolver by pinning pip < 20.3, see
+#   https://github.com/pypa/pip/issues/9187
+# * Pinning dependencies requires tox >= 3.2.0, see
+#   https://tox.readthedocs.io/en/latest/config.html#conf-requires
+# * It is also necessary to pin virtualenv as a newer virtualenv would still
+#   lead to fetching the latest pip in the func* tox targets, see
+#   https://stackoverflow.com/a/38133283
+requires = pip < 20.3
+           virtualenv < 20.0
+# NOTE: https://wiki.canonical.com/engineering/OpenStack/InstallLatestToxOnOsci
+minversion = 3.2.0
+
+[testenv]
+setenv = VIRTUAL_ENV={envdir}
+         PYTHONHASHSEED=0
+whitelist_externals = juju
+passenv = HOME TERM CS_* OS_* TEST_*
+deps = -r{toxinidir}/test-requirements.txt
+install_command =
+  pip install {opts} {packages}
+
+[testenv:init-vault]
+commands = functest-configure -m {posargs}
+
+[testenv:venv]
+commands = {posargs}


### PR DESCRIPTION
This change adds a tox.ini entry to kick off the
`auto_initialize_no_validation` function provided by
zaza-openstack-tests.

Usage:

  tox -e init-vault -- $MODEL_NAME

Co-Authored-By: Felipe Reyes <felipe.reyes@canonical.com>