### PR TITLE
Add scripts to generate reports.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ func-results.json
 *tempest.conf
 tools/*/tempest/
 tools/1-deploy/simplestreams
+report/report/**

--- a/report/bin/catalog_list.sh
+++ b/report/bin/catalog_list.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -xe
+
+openstack catalog list

--- a/report/bin/ceph_tests.sh
+++ b/report/bin/ceph_tests.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -xe
+
+juju run -u ceph-mon/leader -- sudo ceph osd lspools
+juju run -u ceph-mon/leader -- sudo ceph osd df
+juju run -u ceph-mon/leader -- sudo rados -p cinder-ceph ls
+juju run -u ceph-mon/leader -- sudo rados -p glance ls

--- a/report/bin/hypervisor_list.sh
+++ b/report/bin/hypervisor_list.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -xe
+
+openstack hypervisor list

--- a/report/bin/image_list.sh
+++ b/report/bin/image_list.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -xe
+
+openstack image list

--- a/report/bin/instance_launch.sh
+++ b/report/bin/instance_launch.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -xe
+
+openstack keypair create --public-key ~/.ssh/id_rsa.pub mykey || true
+
+private_network_id="$(openstack network list |grep private | awk '{print $2}')"
+openstack server create --wait --image bionic-s390x --flavor m1.small --key-name mykey --nic net-id=$private_network_id my-bionic-s390x

--- a/report/bin/instance_ssh.sh
+++ b/report/bin/instance_ssh.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -x
+
+ip_addr="$(openstack floating ip create ext_net | grep floating_ip_address | awk '{print $4}')"
+ssh-keygen -f ~/.ssh/known_hosts -R $ip_addr
+openstack server add floating ip my-bionic-s390x $ip_addr
+sleep 30
+ssh $ip_addr -i ~/.ssh/id_rsa -oStrictHostKeyChecking=accept-new echo SSH works
+openstack server remove floating ip my-bionic-s390x $ip_addr

--- a/report/bin/juju_status.sh
+++ b/report/bin/juju_status.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -xe
+
+juju status

--- a/report/bin/network_agent_list.sh
+++ b/report/bin/network_agent_list.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -xe
+
+openstack network agent list

--- a/report/bin/network_extension_list.sh
+++ b/report/bin/network_extension_list.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -xe
+
+openstack extension list --network

--- a/report/bin/network_list.sh
+++ b/report/bin/network_list.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -xe
+
+openstack network list

--- a/report/bin/openstack_origin.sh
+++ b/report/bin/openstack_origin.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+output=''
+for application in $(juju status | grep charms | awk '{print $1}'); do
+    for config in openstack-origin source; do
+        set -x
+        origin="$(juju config $application $config 2>/dev/null)"
+        exit_code=$?
+        set +x
+        if [[ "$exit_code" == "0" ]]; then
+            output="$output\n$application: $config=$origin"
+            break
+        fi
+    done
+done
+echo -e $output

--- a/report/bin/tempest_smoke.sh
+++ b/report/bin/tempest_smoke.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -xe
+
+cd ../tools/2-configure/tempest/
+tox -e smoke

--- a/report/test_and_report.sh
+++ b/report/test_and_report.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#LA_TEMP
+
+set -x
+
+rm -rf report/
+mkdir report/
+
+bin/tempest_smoke.sh > report/tempest_smoke.txt 2>&1
+
+. ../openrcv3_domain
+bin/juju_status.sh > report/juju_status.txt 2>&1
+bin/hypervisor_list.sh > report/hypervisor_list.txt 2>&1
+bin/network_agent_list.sh > report/network_agent_list.txt 2>&1
+bin/network_extension_list.sh > report/network_extension_list.txt 2>&1
+bin/network_list.sh > report/network_list.txt 2>&1
+bin/image_list.sh > report/image_list.txt 2>&1
+bin/ceph_tests.sh > report/ceph_tests.txt 2>&1
+bin/openstack_origin.sh > report/openstack_origin.txt 2>&1
+
+. ../openrcv3_project
+bin/catalog_list.sh > report/catalog_list.txt 2>&1
+bin/instance_launch.sh > report/instance_launch.txt 2>&1
+bin/instance_ssh.sh > report/instance_ssh.txt 2>&1


### PR DESCRIPTION
The entry point to generate the reports is `report/test_and_report.sh`,
this script will run tempest smoke tests, a series of openstack and ceph
commands.

Co-Authored-By: Felipe Reyes <felipe.reyes@canonical.com>