### PR TITLE
Replace 'antelope' channel with '2023.1'

### DIFF
--- a/bundles/lpar/jammy-antelope-edge.yaml
+++ b/bundles/lpar/jammy-antelope-edge.yaml
@@ -2,7 +2,7 @@ local_overlay_enabled: False
 
 variables:
   openstack-origin:    &openstack-origin     cloud:jammy-antelope
-  openstack-charm-channel: &openstack-charm-channel antelope/edge
+  openstack-charm-channel: &openstack-charm-channel 2023.1/edge
   ceph-charm-channel: &ceph-charm-channel quincy/edge
   mysql-charm-channel: &mysql-charm-channel 8.0/edge
 machines:

--- a/bundles/lpar/jammy-antelope-ovn-edge.yaml
+++ b/bundles/lpar/jammy-antelope-ovn-edge.yaml
@@ -10,7 +10,7 @@ local_overlay_enabled: False
 series: jammy
 variables:
   openstack-origin:        &openstack-origin        cloud:jammy-antelope
-  openstack-charm-channel: &openstack-charm-channel antelope/edge
+  openstack-charm-channel: &openstack-charm-channel 2023.1/edge
   ovn-charm-channel:       &ovn-charm-channel       23.03/edge
   ceph-charm-channel:      &ceph-charm-channel      quincy/edge
   mysql-charm-channel:     &mysql-charm-channel     8.0/edge

--- a/bundles/lpar/lunar-antelope-edge.yaml
+++ b/bundles/lpar/lunar-antelope-edge.yaml
@@ -2,7 +2,7 @@ local_overlay_enabled: False
 
 variables:
   openstack-origin:    &openstack-origin     distro
-  openstack-charm-channel: &openstack-charm-channel antelope/edge
+  openstack-charm-channel: &openstack-charm-channel 2023.1/edge
   ceph-charm-channel: &ceph-charm-channel quincy/edge
   mysql-charm-channel: &mysql-charm-channel 8.0/edge
 machines:

--- a/bundles/lpar/lunar-antelope-ovn-edge.yaml
+++ b/bundles/lpar/lunar-antelope-ovn-edge.yaml
@@ -10,7 +10,7 @@ local_overlay_enabled: False
 series: lunar
 variables:
   openstack-origin:        &openstack-origin        distro
-  openstack-charm-channel: &openstack-charm-channel antelope/edge
+  openstack-charm-channel: &openstack-charm-channel 2023.1/edge
   ovn-charm-channel:       &ovn-charm-channel       23.03/edge
   ceph-charm-channel:      &ceph-charm-channel      quincy/edge
   mysql-charm-channel:     &mysql-charm-channel     8.0/edge


### PR DESCRIPTION
The OpenStack project is adopting a new strategy to version their releases where the codenames are only used for marketing purposes where branches and similar artifacts use '2023.1', for the case of Charmed OpenStack that means the tracks are named '2023.1' instead of 'antelope'.