### PR TITLE
Drop 'source' from mysql-router

### DIFF
--- a/bundles/lpar/jammy-antelope-edge.yaml
+++ b/bundles/lpar/jammy-antelope-edge.yaml
@@ -195,8 +195,6 @@ applications:
     channel: *ceph-charm-channel
   cinder-mysql-router:
     charm: ch:mysql-router
-    options:
-      source: *openstack-origin
     channel: *mysql-charm-channel
   cinder:
     annotations:
@@ -221,8 +219,6 @@ applications:
     channel: *openstack-charm-channel
   glance-mysql-router:
     charm: ch:mysql-router
-    options:
-      source: *openstack-origin
     channel: *mysql-charm-channel
   glance:
     annotations:
@@ -238,8 +234,6 @@ applications:
     channel: *openstack-charm-channel
   keystone-mysql-router:
     charm: ch:mysql-router
-    options:
-      source: *openstack-origin
     channel: *mysql-charm-channel
   keystone:
     annotations:
@@ -270,8 +264,6 @@ applications:
     channel: *mysql-charm-channel
   neutron-mysql-router:
     charm: ch:mysql-router
-    options:
-      source: *openstack-origin
     channel: *mysql-charm-channel
   neutron-api:
     annotations:
@@ -290,8 +282,6 @@ applications:
     channel: *openstack-charm-channel
   placement-mysql-router:
     charm: ch:mysql-router
-    options:
-      source: *openstack-origin
     channel: *mysql-charm-channel
   placement:
     annotations:
@@ -328,8 +318,6 @@ applications:
     channel: *openstack-charm-channel
   nova-mysql-router:
     charm: ch:mysql-router
-    options:
-      source: *openstack-origin
     channel: *mysql-charm-channel
   nova-cloud-controller:
     annotations:
@@ -363,8 +351,6 @@ applications:
     channel: *openstack-charm-channel
   dashboard-mysql-router:
     charm: ch:mysql-router
-    options:
-      source: *openstack-origin
     channel: *mysql-charm-channel
   openstack-dashboard:
     annotations:
@@ -388,8 +374,6 @@ applications:
     channel: 3.9/edge
   vault-mysql-router:
     charm: ch:mysql-router
-    options:
-      source: *openstack-origin
     channel: *mysql-charm-channel
   vault:
     charm: ch:vault

--- a/bundles/lpar/jammy-antelope-ovn-edge.yaml
+++ b/bundles/lpar/jammy-antelope-ovn-edge.yaml
@@ -205,8 +205,6 @@ applications:
     channel: *ceph-charm-channel
   cinder-mysql-router:
     charm: ch:mysql-router
-    options:
-      source: *openstack-origin
     channel: *mysql-charm-channel
   cinder:
     annotations:
@@ -231,8 +229,6 @@ applications:
     channel: *openstack-charm-channel
   glance-mysql-router:
     charm: ch:mysql-router
-    options:
-      source: *openstack-origin
     channel: *mysql-charm-channel
   glance:
     annotations:
@@ -248,8 +244,6 @@ applications:
     channel: *openstack-charm-channel
   keystone-mysql-router:
     charm: ch:mysql-router
-    options:
-      source: *openstack-origin
     channel: *mysql-charm-channel
   keystone:
     annotations:
@@ -265,8 +259,6 @@ applications:
     channel: *openstack-charm-channel
   neutron-mysql-router:
     charm: ch:mysql-router
-    options:
-      source: *openstack-origin
     channel: *mysql-charm-channel
   neutron-api:
     annotations:
@@ -288,8 +280,6 @@ applications:
     channel: *openstack-charm-channel
   placement-mysql-router:
     charm: ch:mysql-router
-    options:
-      source: *openstack-origin
     channel: *mysql-charm-channel
   placement:
     annotations:
@@ -305,8 +295,6 @@ applications:
     channel: *openstack-charm-channel
   nova-mysql-router:
     charm: ch:mysql-router
-    options:
-      source: *openstack-origin
     channel: *mysql-charm-channel
   nova-cloud-controller:
     annotations:
@@ -340,8 +328,6 @@ applications:
     channel: *openstack-charm-channel
   dashboard-mysql-router:
     charm: ch:mysql-router
-    options:
-      source: *openstack-origin
     channel: *mysql-charm-channel
   openstack-dashboard:
     annotations:
@@ -399,8 +385,6 @@ applications:
     channel: *ovn-charm-channel
   vault-mysql-router:
     charm: ch:mysql-router
-    options:
-      source: *openstack-origin
     channel: *mysql-charm-channel
   vault:
     charm: ch:vault

--- a/bundles/lpar/lunar-antelope-edge.yaml
+++ b/bundles/lpar/lunar-antelope-edge.yaml
@@ -197,8 +197,6 @@ applications:
     channel: *ceph-charm-channel
   cinder-mysql-router:
     charm: ch:mysql-router
-    options:
-      source: *openstack-origin
     channel: *mysql-charm-channel
   cinder:
     annotations:
@@ -223,8 +221,6 @@ applications:
     channel: *openstack-charm-channel
   glance-mysql-router:
     charm: ch:mysql-router
-    options:
-      source: *openstack-origin
     channel: *mysql-charm-channel
   glance:
     annotations:
@@ -240,8 +236,6 @@ applications:
     channel: *openstack-charm-channel
   keystone-mysql-router:
     charm: ch:mysql-router
-    options:
-      source: *openstack-origin
     channel: *mysql-charm-channel
   keystone:
     annotations:
@@ -272,8 +266,6 @@ applications:
     channel: *mysql-charm-channel
   neutron-mysql-router:
     charm: ch:mysql-router
-    options:
-      source: *openstack-origin
     channel: *mysql-charm-channel
   neutron-api:
     annotations:
@@ -292,8 +284,6 @@ applications:
     channel: *openstack-charm-channel
   placement-mysql-router:
     charm: ch:mysql-router
-    options:
-      source: *openstack-origin
     channel: *mysql-charm-channel
   placement:
     annotations:
@@ -330,8 +320,6 @@ applications:
     channel: *openstack-charm-channel
   nova-mysql-router:
     charm: ch:mysql-router
-    options:
-      source: *openstack-origin
     channel: *mysql-charm-channel
   nova-cloud-controller:
     annotations:
@@ -365,8 +353,6 @@ applications:
     channel: *openstack-charm-channel
   dashboard-mysql-router:
     charm: ch:mysql-router
-    options:
-      source: *openstack-origin
     channel: *mysql-charm-channel
   openstack-dashboard:
     annotations:
@@ -390,8 +376,6 @@ applications:
     channel: 3.9/edge
   vault-mysql-router:
     charm: ch:mysql-router
-    options:
-      source: *openstack-origin
     channel: *mysql-charm-channel
   vault:
     charm: ch:vault

--- a/bundles/lpar/lunar-antelope-ovn-edge.yaml
+++ b/bundles/lpar/lunar-antelope-ovn-edge.yaml
@@ -205,8 +205,6 @@ applications:
     channel: *ceph-charm-channel
   cinder-mysql-router:
     charm: ch:mysql-router
-    options:
-      source: *openstack-origin
     channel: *mysql-charm-channel
   cinder:
     annotations:
@@ -231,8 +229,6 @@ applications:
     channel: *openstack-charm-channel
   glance-mysql-router:
     charm: ch:mysql-router
-    options:
-      source: *openstack-origin
     channel: *mysql-charm-channel
   glance:
     annotations:
@@ -248,8 +244,6 @@ applications:
     channel: *openstack-charm-channel
   keystone-mysql-router:
     charm: ch:mysql-router
-    options:
-      source: *openstack-origin
     channel: *mysql-charm-channel
   keystone:
     annotations:
@@ -265,8 +259,6 @@ applications:
     channel: *openstack-charm-channel
   neutron-mysql-router:
     charm: ch:mysql-router
-    options:
-      source: *openstack-origin
     channel: *mysql-charm-channel
   neutron-api:
     annotations:
@@ -288,8 +280,6 @@ applications:
     channel: *openstack-charm-channel
   placement-mysql-router:
     charm: ch:mysql-router
-    options:
-      source: *openstack-origin
     channel: *mysql-charm-channel
   placement:
     annotations:
@@ -305,8 +295,6 @@ applications:
     channel: *openstack-charm-channel
   nova-mysql-router:
     charm: ch:mysql-router
-    options:
-      source: *openstack-origin
     channel: *mysql-charm-channel
   nova-cloud-controller:
     annotations:
@@ -340,8 +328,6 @@ applications:
     channel: *openstack-charm-channel
   dashboard-mysql-router:
     charm: ch:mysql-router
-    options:
-      source: *openstack-origin
     channel: *mysql-charm-channel
   openstack-dashboard:
     annotations:
@@ -399,8 +385,6 @@ applications:
     channel: *ovn-charm-channel
   vault-mysql-router:
     charm: ch:mysql-router
-    options:
-      source: *openstack-origin
     channel: *mysql-charm-channel
   vault:
     charm: ch:vault


### PR DESCRIPTION
mysql-router sources its packages from the distro, there is no need to configure the 'source' key.