### PR TITLE
Add Juju 3.x support

### DIFF
--- a/_openrcv3_get_root_ca
+++ b/_openrcv3_get_root_ca
@@ -5,4 +5,4 @@ if [ -d ~/snap/openstackclients/common/ ]; then
 else
   _root_ca=/tmp/root-ca.crt
 fi
-juju run $_juju_model_arg --unit vault/leader 'leader-get root-ca' | tee $_root_ca >/dev/null 2>&1
+juju exec $_juju_model_arg --unit vault/leader 'leader-get root-ca' | tee $_root_ca >/dev/null 2>&1

--- a/openrcv3_domain
+++ b/openrcv3_domain
@@ -10,9 +10,9 @@ _keystone_vip=$(juju config $_juju_model_arg keystone vip)
 if [ -n "$_keystone_vip" ]; then
     _keystone_ip=$(echo $_keystone_vip | awk '{print $1}')
 else
-    _keystone_ip=$(juju run $_juju_model_arg --unit keystone/leader -- 'network-get --bind-address public')
+    _keystone_ip=$(juju exec $_juju_model_arg --unit keystone/leader -- 'network-get --bind-address public')
 fi
-_password=$(juju run $_juju_model_arg --unit keystone/leader 'leader-get admin_passwd')
+_password=$(juju exec $_juju_model_arg --unit keystone/leader 'leader-get admin_passwd')
 
 . $(dirname ${BASH_SOURCE[0]})/_openrcv3_get_root_ca
 if [ ! -z "$_root_ca" -a -s "$_root_ca" ]; then

--- a/openrcv3_project
+++ b/openrcv3_project
@@ -10,9 +10,9 @@ _keystone_vip=$(juju config $_juju_model_arg keystone vip)
 if [ -n "$_keystone_vip" ]; then
     _keystone_ip=$(echo $_keystone_vip | awk '{print $1}')
 else
-    _keystone_ip=$(juju run $_juju_model_arg --unit keystone/leader -- 'network-get --bind-address public')
+    _keystone_ip=$(juju exec $_juju_model_arg --unit keystone/leader -- 'network-get --bind-address public')
 fi
-_password=$(juju run $_juju_model_arg --unit keystone/leader 'leader-get admin_passwd')
+_password=$(juju exec $_juju_model_arg --unit keystone/leader 'leader-get admin_passwd')
 
 . $(dirname ${BASH_SOURCE[0]})/_openrcv3_get_root_ca
 if [ ! -z "$_root_ca" -a -s "$_root_ca" ]; then

--- a/report/bin/ceph_tests.sh
+++ b/report/bin/ceph_tests.sh
@@ -2,7 +2,7 @@
 
 set -xe
 
-juju run -u ceph-mon/leader -- sudo ceph osd lspools
-juju run -u ceph-mon/leader -- sudo ceph osd df
-juju run -u ceph-mon/leader -- sudo rados -p cinder-ceph ls
-juju run -u ceph-mon/leader -- sudo rados -p glance ls
+juju exec -u ceph-mon/leader -- sudo ceph osd lspools
+juju exec -u ceph-mon/leader -- sudo ceph osd df
+juju exec -u ceph-mon/leader -- sudo rados -p cinder-ceph ls
+juju exec -u ceph-mon/leader -- sudo rados -p glance ls

--- a/report/bin/openstack_origin.sh
+++ b/report/bin/openstack_origin.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 output=''
-for application in $(juju status | grep charms | awk '{print $1}'); do
+for application in $(juju status --format json | jq -r '.applications|keys|@tsv'); do
     for config in openstack-origin source; do
         set -x
         origin="$(juju config $application $config 2>/dev/null)"

--- a/report/bin/remove_all_instances.sh
+++ b/report/bin/remove_all_instances.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -xe
+
+. ../openrcv3_project
+
+for INSTANCE_ID in $(openstack server list --all-projects -f value -c ID);do
+    openstack server delete $INSTANCE_ID
+done

--- a/report/bin/tempest_smoke.sh
+++ b/report/bin/tempest_smoke.sh
@@ -3,4 +3,4 @@
 set -xe
 
 cd ../tools/2-configure/tempest/
-tox -e smoke
+env https_proxy="http://squid.internal:3128" tox -e smoke

--- a/report/test_and_report.sh
+++ b/report/test_and_report.sh
@@ -10,15 +10,15 @@ bin/tempest_smoke.sh > report/tempest_smoke.txt 2>&1
 
 . ../openrcv3_domain
 bin/juju_status.sh > report/juju_status.txt 2>&1
-bin/hypervisor_list.sh > report/hypervisor_list.txt 2>&1
 bin/network_agent_list.sh > report/network_agent_list.txt 2>&1
 bin/network_extension_list.sh > report/network_extension_list.txt 2>&1
 bin/network_list.sh > report/network_list.txt 2>&1
-bin/image_list.sh > report/image_list.txt 2>&1
 bin/ceph_tests.sh > report/ceph_tests.txt 2>&1
 bin/openstack_origin.sh > report/openstack_origin.txt 2>&1
 
 . ../openrcv3_project
+bin/hypervisor_list.sh > report/hypervisor_list.txt 2>&1
+bin/image_list.sh > report/image_list.txt 2>&1
 bin/catalog_list.sh > report/catalog_list.txt 2>&1
 bin/instance_launch.sh > report/instance_launch.txt 2>&1
 bin/instance_ssh.sh > report/instance_ssh.txt 2>&1

--- a/report/test_and_report.sh
+++ b/report/test_and_report.sh
@@ -5,6 +5,7 @@ set -x
 
 rm -rf report/
 mkdir report/
+bin/remove_all_instances.sh
 
 bin/tempest_smoke.sh > report/tempest_smoke.txt 2>&1
 

--- a/tools/1-deploy/setup-ceph-osd.sh
+++ b/tools/1-deploy/setup-ceph-osd.sh
@@ -21,10 +21,11 @@ for UNIT in $CEPH_OSD_UNITS; do
   PARTITION="${DEVICE}1"
 
   if [[ "$SERIES" > "bionic" ]]; then
-    juju run -u $UNIT "sudo fdasd -a $DEVICE -l ceph && sudo partprobe"
-    juju run -u $UNIT "test -e $PARTITION"
+    juju ssh $UNIT "sudo fdasd -a $DEVICE -l ceph && sudo partprobe"
+    juju ssh $UNIT "test -e $PARTITION"
   fi
 
-  juju run-action --wait $UNIT zap-disk devices=$PARTITION i-really-mean-it=true
-  juju run-action --wait $UNIT add-disk osd-devices=$PARTITION
+  # `juju run` runs actions on juju-3.x
+  juju run $UNIT zap-disk devices=$PARTITION i-really-mean-it=true
+  juju run $UNIT add-disk osd-devices=$PARTITION
 done

--- a/tools/2-configure/profiles/s390x-multi-lpar-v3
+++ b/tools/2-configure/profiles/s390x-multi-lpar-v3
@@ -11,7 +11,7 @@
 [[ -z "$CIDR_PRIV" ]] && export CIDR_PRIV="172.16.0.0/12"
 [[ -z "$SWIFT_IP" ]] && export SWIFT_IP="10.245.161.162"  # Cirros image hosted on serverstack
 
-juju run --unit ovn-central/leader 'echo This is an OVN setup' 2>/dev/null && is_ovn_setup=true || is_ovn_setup=false
+juju exec --unit ovn-central/leader 'echo This is an OVN setup' 2>/dev/null && is_ovn_setup=true || is_ovn_setup=false
 
 # Accept private network type as first parameter. If unspecified, assume:
 # - 'gre' for an OVS setup,
@@ -69,9 +69,9 @@ router=$(neutron router-list | grep provider-router | awk '{ print $2}')
 keystone_unit=$(juju status keystone|grep -i workload -A1|tail -n1|awk '{print $1}'|tr -d '*')
 dashboard_unit=$(juju status openstack-dashboard|grep -i workload -A1|tail -n1|awk '{print $1}'|tr -d '*')
 ncc_unit=$(juju status nova-cloud-controller|grep -i workload -A1|tail -n1|awk '{print $1}'|tr -d '*')
-keystone=$(juju run --unit ${keystone_unit} "unit-get private-address")
-dashboard=$(juju run --unit ${dashboard_unit} "unit-get private-address")
-ncc=$(juju run --unit ${ncc_unit} "unit-get private-address")
+keystone=$(juju exec --unit ${keystone_unit} "unit-get private-address")
+dashboard=$(juju exec --unit ${dashboard_unit} "unit-get private-address")
+ncc=$(juju exec --unit ${ncc_unit} "unit-get private-address")
 http=${OS_AUTH_PROTOCOL:-http}
 default_domain_id=$(openstack domain list | awk '/admin_domain/ {print $2}')
 admin_password=${OS_PASSWORD:-openstack}

--- a/tools/2-configure/templates/tempest/tempest-v3.conf.template
+++ b/tools/2-configure/templates/tempest/tempest-v3.conf.template
@@ -99,3 +99,7 @@ api_v3=true
 # NOTE(lourot): We're using Ubuntu images for testing.
 image_ssh_user=ubuntu
 image_alt_ssh_user=ubuntu
+
+[service-clients]
+# Default is 60s which is not enough for resource constrained environments.
+http_timeout = 120

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,9 @@ skipsdist = True
 [testenv]
 setenv = VIRTUAL_ENV={envdir}
          PYTHONHASHSEED=0
-passenv = HOME TERM
+passenv =
+    HOME
+    TERM
 
 [testenv:clients]
 deps = -r{toxinidir}/test-requirements.txt


### PR DESCRIPTION
Summary of changes:

- Use 'juju ssh' for running command(s) on a single unit
- Replace 'juju run-action' with 'juju run'
- Replace 'juju run' with 'juju exec'
- Remove all instances running before running smoke tests
- Use opercv3_project for hypervisor and image list
- Format passenv to make it compatible with tox4
- Bump up http timeout for service clients
- Use jq to get list of deployed applications
- Set https_proxy to get tempest git repo