### PR TITLE
Add 2024.1 (Caracal) bundles

### DIFF
--- a/bundles/lpar/jammy-caracal-edge.yaml
+++ b/bundles/lpar/jammy-caracal-edge.yaml
@@ -1,0 +1,449 @@
+local_overlay_enabled: False
+
+variables:
+  openstack-origin:    &openstack-origin     cloud:jammy-caracal
+  openstack-charm-channel: &openstack-charm-channel 2024.1/edge
+  ceph-charm-channel: &ceph-charm-channel squid/edge
+  mysql-charm-channel: &mysql-charm-channel 8.0/edge
+machines:
+  '0':
+    series: jammy
+    constraints: "arch=s390x"
+  '1':
+    series: jammy
+    constraints: "arch=s390x"
+  '2':
+    series: jammy
+    constraints: "arch=s390x"
+  '3':
+    series: jammy
+    constraints: "arch=s390x"
+  '4':
+    series: jammy
+    constraints: "arch=s390x"
+relations:
+- - nova-compute:amqp
+  - rabbitmq-server:amqp
+- - neutron-gateway:amqp
+  - rabbitmq-server:amqp
+- - keystone:shared-db
+  - keystone-mysql-router:shared-db
+- - nova-cloud-controller:identity-service
+  - keystone:identity-service
+- - glance:identity-service
+  - keystone:identity-service
+- - neutron-api:identity-service
+  - keystone:identity-service
+- - neutron-openvswitch:neutron-plugin-api
+  - neutron-api:neutron-plugin-api
+- - neutron-api:shared-db
+  - neutron-mysql-router:shared-db
+- - neutron-api:amqp
+  - rabbitmq-server:amqp
+- - neutron-gateway:neutron-plugin-api
+  - neutron-api:neutron-plugin-api
+- - glance:shared-db
+  - glance-mysql-router:shared-db
+- - glance:amqp
+  - rabbitmq-server:amqp
+- - nova-cloud-controller:image-service
+  - glance:image-service
+- - nova-compute:image-service
+  - glance:image-service
+- - nova-cloud-controller:cloud-compute
+  - nova-compute:cloud-compute
+- - nova-cloud-controller:amqp
+  - rabbitmq-server:amqp
+- - nova-cloud-controller:quantum-network-service
+  - neutron-gateway:quantum-network-service
+- - nova-compute:neutron-plugin
+  - neutron-openvswitch:neutron-plugin
+- - neutron-openvswitch:amqp
+  - rabbitmq-server:amqp
+- - openstack-dashboard:identity-service
+  - keystone:identity-service
+- - openstack-dashboard:shared-db
+  - dashboard-mysql-router:shared-db
+- - nova-cloud-controller:shared-db
+  - nova-mysql-router:shared-db
+- - nova-cloud-controller:neutron-api
+  - neutron-api:neutron-api
+- - cinder:image-service
+  - glance:image-service
+- - cinder:amqp
+  - rabbitmq-server:amqp
+- - cinder:identity-service
+  - keystone:identity-service
+- - cinder:cinder-volume-service
+  - nova-cloud-controller:cinder-volume-service
+- - placement:shared-db
+  - placement-mysql-router:shared-db
+- - placement
+  - keystone
+- - placement
+  - nova-cloud-controller
+- - keystone-mysql-router:db-router
+  - mysql:db-router
+- - cinder-mysql-router:db-router
+  - mysql:db-router
+- - nova-mysql-router:db-router
+  - mysql:db-router
+- - glance-mysql-router:db-router
+  - mysql:db-router
+- - neutron-mysql-router:db-router
+  - mysql:db-router
+- - dashboard-mysql-router:db-router
+  - mysql:db-router
+- - placement-mysql-router:db-router
+  - mysql:db-router
+
+- - cinder-ceph:storage-backend
+  - cinder:storage-backend
+- - ceph-mon:client
+  - nova-compute:ceph
+- - nova-compute:ceph-access
+  - cinder-ceph:ceph-access
+- - cinder:shared-db
+  - cinder-mysql-router:shared-db
+- - ceph-mon:client
+  - cinder-ceph:ceph
+- - ceph-mon:client
+  - glance:ceph
+- - ceph-osd:mon
+  - ceph-mon:osd
+- - ceph-radosgw:mon
+  - ceph-mon:radosgw
+- - ceph-radosgw:identity-service
+  - keystone:identity-service
+
+# Swift relations
+- - swift-proxy:identity-service
+  - keystone:identity-service
+- - swift-proxy:swift-storage
+  - swift-storage-z1:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z2:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z3:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z4:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z5:swift-storage
+
+# Vault
+- - vault:shared-db
+  - vault-mysql-router:shared-db
+- - vault-mysql-router:db-router
+  - mysql:db-router
+- - neutron-api:certificates
+  - vault:certificates
+- - vault:certificates
+  - cinder:certificates
+- - vault:certificates
+  - glance:certificates
+- - vault:certificates
+  - keystone:certificates
+- - vault:certificates
+  - nova-cloud-controller:certificates
+- - vault:certificates
+  - openstack-dashboard:certificates
+- - vault:certificates
+  - placement:certificates
+- - vault:certificates
+  - swift-proxy:certificates
+
+series: jammy
+applications:
+  ceph-mon:
+    annotations:
+      gui-x: '750'
+      gui-y: '500'
+    charm: ch:ceph-mon
+    num_units: 3
+    options:
+      expected-osd-count: 3
+      # NOTE(lourot): our s390x test lab's LPARs have so little disk space that
+      # we need to tell ceph-mon to tolerate OSD disk usage up to 98% or it may
+      # refuse to start (default is 95%):
+      config-flags: "{'mon': {'mon data avail crit': 2}}"
+    to:
+    - 'lxd:1'
+    - 'lxd:2'
+    - 'lxd:3'
+    channel: *ceph-charm-channel
+  ceph-osd:
+    annotations:
+      gui-x: '1000'
+      gui-y: '500'
+    charm: ch:ceph-osd
+    num_units: 3
+    options:
+      osd-devices: /dev/sdb
+    to:
+    - '1'
+    - '2'
+    - '3'
+    channel: *ceph-charm-channel
+  ceph-radosgw:
+    annotations:
+      gui-x: '1000'
+      gui-y: '250'
+    charm: ch:ceph-radosgw
+    num_units: 1
+    to:
+    - lxd:0
+    channel: *ceph-charm-channel
+  cinder-mysql-router:
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  cinder:
+    annotations:
+      gui-x: '750'
+      gui-y: '0'
+    charm: ch:cinder
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      block-device: None
+      glance-api-version: 2
+      worker-multiplier: 0.25
+    to:
+    - lxd:1
+    channel: *openstack-charm-channel
+  cinder-ceph:
+    annotations:
+      gui-x: '750'
+      gui-y: '250'
+    charm: ch:cinder-ceph
+    num_units: 0
+    channel: *openstack-charm-channel
+  glance-mysql-router:
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  glance:
+    annotations:
+      gui-x: '250'
+      gui-y: '0'
+    charm: ch:glance
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      worker-multiplier: 0.25
+    to:
+    - lxd:0
+    channel: *openstack-charm-channel
+  keystone-mysql-router:
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  keystone:
+    annotations:
+      gui-x: '500'
+      gui-y: '0'
+    charm: ch:keystone
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      admin-password: openstack
+      worker-multiplier: 0.25
+    to:
+    - lxd:0
+    channel: *openstack-charm-channel
+  mysql:
+    annotations:
+      gui-x: '0'
+      gui-y: '250'
+    charm: ch:mysql-innodb-cluster
+    num_units: 3
+    options:
+      max-connections: 1000
+      innodb-buffer-pool-size: 256M
+    to:
+    - lxd:0
+    - lxd:3
+    - lxd:4
+    channel: *mysql-charm-channel
+  neutron-mysql-router:
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  neutron-api:
+    annotations:
+      gui-x: '500'
+      gui-y: '500'
+    charm: ch:neutron-api
+    num_units: 1
+    options:
+      manage-neutron-plugin-legacy-mode: true
+      openstack-origin: *openstack-origin
+      neutron-security-groups: true
+      flat-network-providers: physnet1
+      worker-multiplier: 0.25
+    to:
+    - lxd:4
+    channel: *openstack-charm-channel
+  placement-mysql-router:
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  placement:
+    annotations:
+      gui-x: '0'
+      gui-y: '500'
+    charm: ch:placement
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      worker-multiplier: 0.25
+    to:
+    - lxd:4
+    channel: *openstack-charm-channel
+  neutron-gateway:
+    annotations:
+      gui-x: '0'
+      gui-y: '0'
+    charm: ch:neutron-gateway
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      bridge-mappings: physnet1:br-ex
+      data-port: br-ex:encc003
+      worker-multiplier: 0.25
+    to:
+    - '0'
+    channel: *openstack-charm-channel
+  neutron-openvswitch:
+    annotations:
+      gui-x: '250'
+      gui-y: '500'
+    charm: ch:neutron-openvswitch
+    num_units: 0
+    channel: *openstack-charm-channel
+  nova-mysql-router:
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  nova-cloud-controller:
+    annotations:
+      gui-x: '0'
+      gui-y: '500'
+    charm: ch:nova-cloud-controller
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      network-manager: Neutron
+      worker-multiplier: 0.25
+    to:
+    - lxd:2
+    channel: *openstack-charm-channel
+  nova-compute:
+    annotations:
+      gui-x: '250'
+      gui-y: '250'
+    charm: ch:nova-compute
+    num_units: 3
+    options:
+      config-flags: default_ephemeral_format=ext4
+      openstack-origin: *openstack-origin
+      enable-live-migration: true
+      enable-resize: true
+      migration-auth-type: ssh
+    to:
+    - '1'
+    - '2'
+    - '3'
+    channel: *openstack-charm-channel
+  dashboard-mysql-router:
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  openstack-dashboard:
+    annotations:
+      gui-x: '500'
+      gui-y: '-250'
+    charm: ch:openstack-dashboard
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    to:
+    - lxd:0
+    channel: *openstack-charm-channel
+  rabbitmq-server:
+    annotations:
+      gui-x: '500'
+      gui-y: '250'
+    charm: ch:rabbitmq-server
+    num_units: 1
+    to:
+    - lxd:0
+    channel: 3.9/edge
+  vault-mysql-router:
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  vault:
+    charm: ch:vault
+    num_units: 1
+    to:
+    - 'lxd:4'
+    channel: 1.8/edge
+  swift-proxy:
+    charm: ch:swift-proxy
+    num_units: 1
+    options:
+      zone-assignment: manual
+      replicas: 5
+      swift-hash: 62ce298d-cd4a-4087-b7f3-0c71df0127e0
+      openstack-origin: *openstack-origin
+    to:
+      - "lxd:0"
+    channel: *openstack-charm-channel
+  swift-storage-z1:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      zone: 1
+      block-device: /mnt/swift/swift_dist.img|20G
+      overwrite: "false"
+      openstack-origin: *openstack-origin
+    to:
+    - '0'
+    channel: *openstack-charm-channel
+  swift-storage-z2:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      zone: 2
+      block-device: /mnt/swift/swift_dist.img|20G
+      overwrite: "false"
+      openstack-origin: *openstack-origin
+    to:
+    - '1'
+    channel: *openstack-charm-channel
+  swift-storage-z3:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      zone: 3
+      block-device: /mnt/swift/swift_dist.img|20G
+      overwrite: "false"
+      openstack-origin: *openstack-origin
+    to:
+    - '2'
+    channel: *openstack-charm-channel
+  swift-storage-z4:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      zone: 4
+      block-device: /mnt/swift/swift_dist.img|20G
+      overwrite: "false"
+      openstack-origin: *openstack-origin
+    to:
+    - '3'
+    channel: *openstack-charm-channel
+  swift-storage-z5:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      zone: 5
+      block-device: /mnt/swift/swift_dist.img|20G
+      overwrite: "false"
+      openstack-origin: *openstack-origin
+    to:
+    - '4'
+    channel: *openstack-charm-channel

--- a/bundles/lpar/jammy-caracal-ovn-edge.yaml
+++ b/bundles/lpar/jammy-caracal-ovn-edge.yaml
@@ -1,0 +1,460 @@
+# Open Virtual Network (OVN) - requires Train or later
+#
+# NOTE: Please review the value for the configuration option
+#       `bridge-interface-mappings` for the `ovn-chassis` charm.
+#       Refer to the [Open Virtual Network (OVN)](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-ovn.html)
+#       section of the [OpenStack Charms Deployment Guide](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/)
+#       for more information.
+---
+local_overlay_enabled: False
+series: jammy
+variables:
+  openstack-origin:        &openstack-origin        cloud:jammy-caracal
+  openstack-charm-channel: &openstack-charm-channel 2024.1/edge
+  ovn-charm-channel:       &ovn-charm-channel       24.03/edge
+  ceph-charm-channel:      &ceph-charm-channel      squid/edge
+  mysql-charm-channel:     &mysql-charm-channel     8.0/edge
+  data-port:               &data-port               br-ex:9e:5d:5f:52:4e:b0
+  worker-multiplier:       &worker-multiplier       0.25
+  osd-devices:             &osd-devices             /dev/disk/by-label/ceph
+  expected-osd-count:      &expected-osd-count      3
+  expected-mon-count:      &expected-mon-count      3
+machines:
+  '0':
+    series: jammy
+    constraints: "arch=s390x"
+  '1':
+    series: jammy
+    constraints: "arch=s390x"
+  '2':
+    series: jammy
+    constraints: "arch=s390x"
+  '3':
+    series: jammy
+    constraints: "arch=s390x"
+  '4':
+    series: jammy
+    constraints: "arch=s390x"
+relations:
+- - nova-compute:amqp
+  - rabbitmq-server:amqp
+- - keystone:shared-db
+  - keystone-mysql-router:shared-db
+- - nova-cloud-controller:identity-service
+  - keystone:identity-service
+- - glance:identity-service
+  - keystone:identity-service
+- - neutron-api:identity-service
+  - keystone:identity-service
+- - neutron-api:shared-db
+  - neutron-mysql-router:shared-db
+- - neutron-api:amqp
+  - rabbitmq-server:amqp
+- - glance:shared-db
+  - glance-mysql-router:shared-db
+- - glance:amqp
+  - rabbitmq-server:amqp
+- - nova-cloud-controller:image-service
+  - glance:image-service
+- - nova-compute:image-service
+  - glance:image-service
+- - nova-cloud-controller:cloud-compute
+  - nova-compute:cloud-compute
+- - nova-cloud-controller:amqp
+  - rabbitmq-server:amqp
+- - openstack-dashboard:identity-service
+  - keystone:identity-service
+- - openstack-dashboard:shared-db
+  - dashboard-mysql-router:shared-db
+- - nova-cloud-controller:shared-db
+  - nova-mysql-router:shared-db
+- - nova-cloud-controller:neutron-api
+  - neutron-api:neutron-api
+- - cinder:image-service
+  - glance:image-service
+- - cinder:amqp
+  - rabbitmq-server:amqp
+- - cinder:identity-service
+  - keystone:identity-service
+- - cinder:cinder-volume-service
+  - nova-cloud-controller:cinder-volume-service
+- - placement:shared-db
+  - placement-mysql-router:shared-db
+- - placement
+  - keystone
+- - placement
+  - nova-cloud-controller
+- - keystone-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - cinder-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - nova-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - glance-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - neutron-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - dashboard-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - placement-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+
+- - cinder-ceph:storage-backend
+  - cinder:storage-backend
+- - ceph-mon:client
+  - nova-compute:ceph
+- - nova-compute:ceph-access
+  - cinder-ceph:ceph-access
+- - cinder:shared-db
+  - cinder-mysql-router:shared-db
+- - ceph-mon:client
+  - cinder-ceph:ceph
+- - ceph-mon:client
+  - glance:ceph
+- - ceph-osd:mon
+  - ceph-mon:osd
+- - ceph-radosgw:mon
+  - ceph-mon:radosgw
+- - ceph-radosgw:identity-service
+  - keystone:identity-service
+- - vault:shared-db
+  - vault-mysql-router:shared-db
+- - vault-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - neutron-api-plugin-ovn:neutron-plugin
+  - neutron-api:neutron-plugin-api-subordinate
+- - ovn-central:certificates
+  - vault:certificates
+- - ovn-central:ovsdb-cms
+  - neutron-api-plugin-ovn:ovsdb-cms
+- - neutron-api:certificates
+  - vault:certificates
+- - ovn-chassis:nova-compute
+  - nova-compute:neutron-plugin
+- - ovn-chassis:certificates
+  - vault:certificates
+- - ovn-chassis:ovsdb
+  - ovn-central:ovsdb
+- - vault:certificates
+  - neutron-api-plugin-ovn:certificates
+- - vault:certificates
+  - cinder:certificates
+- - vault:certificates
+  - glance:certificates
+- - vault:certificates
+  - keystone:certificates
+- - vault:certificates
+  - nova-cloud-controller:certificates
+- - vault:certificates
+  - openstack-dashboard:certificates
+- - vault:certificates
+  - placement:certificates
+
+# Swift relations
+- - swift-proxy:identity-service
+  - keystone:identity-service
+- - swift-proxy:swift-storage
+  - swift-storage-z1:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z2:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z3:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z4:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z5:swift-storage
+- - vault:certificates
+  - swift-proxy:certificates
+
+applications:
+  ceph-mon:
+    annotations:
+      gui-x: '750'
+      gui-y: '500'
+    charm: ch:ceph-mon
+    num_units: 3
+    options:
+      expected-osd-count: *expected-osd-count
+      monitor-count: *expected-mon-count
+    to:
+    - 'lxd:0'
+    - 'lxd:1'
+    - 'lxd:2'
+    channel: *ceph-charm-channel
+  ceph-osd:
+    annotations:
+      gui-x: '1000'
+      gui-y: '500'
+    charm: ch:ceph-osd
+    num_units: 3
+    options:
+      osd-devices: *osd-devices
+    to:
+    - '0'
+    - '1'
+    - '2'
+    channel: *ceph-charm-channel
+  ceph-radosgw:
+    annotations:
+      gui-x: '1000'
+      gui-y: '250'
+    charm: ch:ceph-radosgw
+    num_units: 1
+    to:
+    - 'lxd:3'
+    channel: *ceph-charm-channel
+  cinder-mysql-router:
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  cinder:
+    annotations:
+      gui-x: '750'
+      gui-y: '0'
+    charm: ch:cinder
+    num_units: 1
+    options:
+      block-device: None
+      glance-api-version: 2
+      worker-multiplier: *worker-multiplier
+      openstack-origin: *openstack-origin
+    to:
+    - 'lxd:3'
+    channel: *openstack-charm-channel
+  cinder-ceph:
+    annotations:
+      gui-x: '750'
+      gui-y: '250'
+    charm: ch:cinder-ceph
+    num_units: 0
+    channel: *openstack-charm-channel
+  glance-mysql-router:
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  glance:
+    annotations:
+      gui-x: '250'
+      gui-y: '0'
+    charm: ch:glance
+    num_units: 1
+    options:
+      worker-multiplier: *worker-multiplier
+      openstack-origin: *openstack-origin
+    to:
+    - 'lxd:4'
+    channel: *openstack-charm-channel
+  keystone-mysql-router:
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  keystone:
+    annotations:
+      gui-x: '500'
+      gui-y: '0'
+    charm: ch:keystone
+    num_units: 1
+    options:
+      worker-multiplier: *worker-multiplier
+      openstack-origin: *openstack-origin
+    to:
+    - 'lxd:3'
+    channel: *openstack-charm-channel
+  neutron-mysql-router:
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  neutron-api:
+    annotations:
+      gui-x: '500'
+      gui-y: '500'
+    charm: ch:neutron-api
+    num_units: 1
+    options:
+      # NOTE(fnordahl): At current state of upstream Neutron development this
+      # is a requirement.  Remove once fixed upstream.
+      enable-ml2-port-security: true
+      neutron-security-groups: true
+      flat-network-providers: physnet1
+      worker-multiplier: *worker-multiplier
+      openstack-origin: *openstack-origin
+      manage-neutron-plugin-legacy-mode: false
+    to:
+    - 'lxd:4'
+    channel: *openstack-charm-channel
+  placement-mysql-router:
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  placement:
+    annotations:
+      gui-x: '0'
+      gui-y: '500'
+    charm: ch:placement
+    num_units: 1
+    options:
+      worker-multiplier: *worker-multiplier
+      openstack-origin: *openstack-origin
+    to:
+    - 'lxd:0'
+    channel: *openstack-charm-channel
+  nova-mysql-router:
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  nova-cloud-controller:
+    annotations:
+      gui-x: '0'
+      gui-y: '500'
+    charm: ch:nova-cloud-controller
+    num_units: 1
+    options:
+      network-manager: Neutron
+      worker-multiplier: *worker-multiplier
+      openstack-origin: *openstack-origin
+    to:
+    - 'lxd:1'
+    channel: *openstack-charm-channel
+  nova-compute:
+    annotations:
+      gui-x: '250'
+      gui-y: '250'
+    charm: ch:nova-compute
+    num_units: 3
+    options:
+      config-flags: default_ephemeral_format=ext4
+      enable-live-migration: true
+      enable-resize: true
+      migration-auth-type: ssh
+      openstack-origin: *openstack-origin
+    to:
+    - '0'
+    - '1'
+    - '2'
+    channel: *openstack-charm-channel
+  dashboard-mysql-router:
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  openstack-dashboard:
+    annotations:
+      gui-x: '500'
+      gui-y: '-250'
+    charm: ch:openstack-dashboard
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    to:
+    - 'lxd:4'
+    channel: *openstack-charm-channel
+  rabbitmq-server:
+    annotations:
+      gui-x: '500'
+      gui-y: '250'
+    charm: ch:rabbitmq-server
+    num_units: 1
+    to:
+    - 'lxd:3'
+    channel: 3.9/edge
+  mysql-innodb-cluster:
+    charm: ch:mysql-innodb-cluster
+    num_units: 3
+    options:
+      max-connections: 1000
+      innodb-buffer-pool-size: 256M
+    to:
+    - 'lxd:0'
+    - 'lxd:1'
+    - 'lxd:2'
+    channel: *mysql-charm-channel
+  neutron-api-plugin-ovn:
+    charm: ch:neutron-api-plugin-ovn
+    channel: *openstack-charm-channel
+  ovn-central:
+    charm: ch:ovn-central
+    num_units: 3
+    options:
+      source: *openstack-origin
+    to:
+    - 'lxd:0'
+    - 'lxd:1'
+    - 'lxd:2'
+    channel: *ovn-charm-channel
+  ovn-chassis:
+    charm: ch:ovn-chassis
+    comment: |
+      Please update the `bridge-interface-mappings` to values suitable for the
+      hardware used in your deployment.  See the referenced documentation at
+      the top of this file.
+    options:
+      ovn-bridge-mappings: physnet1:br-ex
+      bridge-interface-mappings: *data-port
+    channel: *ovn-charm-channel
+  vault-mysql-router:
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  vault:
+    charm: ch:vault
+    num_units: 1
+    to:
+    - 'lxd:4'
+    channel: 1.8/edge
+  swift-proxy:
+    charm: ch:swift-proxy
+    num_units: 1
+    options:
+      zone-assignment: manual
+      replicas: 5
+      swift-hash: 62ce298d-cd4a-4087-b7f3-0c71df0127e0
+      openstack-origin: *openstack-origin
+    to:
+      - "lxd:0"
+    channel: *openstack-charm-channel
+  swift-storage-z1:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      zone: 1
+      block-device: /mnt/swift/swift_dist.img|20G
+      overwrite: "false"
+      openstack-origin: *openstack-origin
+    to:
+    - '0'
+    channel: *openstack-charm-channel
+  swift-storage-z2:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      zone: 2
+      block-device: /mnt/swift/swift_dist.img|20G
+      overwrite: "false"
+      openstack-origin: *openstack-origin
+    to:
+    - '1'
+    channel: *openstack-charm-channel
+  swift-storage-z3:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      zone: 3
+      block-device: /mnt/swift/swift_dist.img|20G
+      overwrite: "false"
+      openstack-origin: *openstack-origin
+    to:
+    - '2'
+    channel: *openstack-charm-channel
+  swift-storage-z4:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      zone: 4
+      block-device: /mnt/swift/swift_dist.img|20G
+      overwrite: "false"
+      openstack-origin: *openstack-origin
+    to:
+    - '3'
+    channel: *openstack-charm-channel
+  swift-storage-z5:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      zone: 5
+      block-device: /mnt/swift/swift_dist.img|20G
+      overwrite: "false"
+      openstack-origin: *openstack-origin
+    to:
+    - '4'
+    channel: *openstack-charm-channel

--- a/bundles/lpar/noble-caracal-edge.yaml
+++ b/bundles/lpar/noble-caracal-edge.yaml
@@ -1,0 +1,449 @@
+local_overlay_enabled: False
+
+variables:
+  openstack-origin:    &openstack-origin     distro
+  openstack-charm-channel: &openstack-charm-channel latest/edge
+  ceph-charm-channel: &ceph-charm-channel latest/edge
+  mysql-charm-channel: &mysql-charm-channel latest/edge
+machines:
+  '0':
+    series: jammy
+    constraints: "arch=s390x"
+  '1':
+    series: jammy
+    constraints: "arch=s390x"
+  '2':
+    series: jammy
+    constraints: "arch=s390x"
+  '3':
+    series: jammy
+    constraints: "arch=s390x"
+  '4':
+    series: jammy
+    constraints: "arch=s390x"
+relations:
+- - nova-compute:amqp
+  - rabbitmq-server:amqp
+- - neutron-gateway:amqp
+  - rabbitmq-server:amqp
+- - keystone:shared-db
+  - keystone-mysql-router:shared-db
+- - nova-cloud-controller:identity-service
+  - keystone:identity-service
+- - glance:identity-service
+  - keystone:identity-service
+- - neutron-api:identity-service
+  - keystone:identity-service
+- - neutron-openvswitch:neutron-plugin-api
+  - neutron-api:neutron-plugin-api
+- - neutron-api:shared-db
+  - neutron-mysql-router:shared-db
+- - neutron-api:amqp
+  - rabbitmq-server:amqp
+- - neutron-gateway:neutron-plugin-api
+  - neutron-api:neutron-plugin-api
+- - glance:shared-db
+  - glance-mysql-router:shared-db
+- - glance:amqp
+  - rabbitmq-server:amqp
+- - nova-cloud-controller:image-service
+  - glance:image-service
+- - nova-compute:image-service
+  - glance:image-service
+- - nova-cloud-controller:cloud-compute
+  - nova-compute:cloud-compute
+- - nova-cloud-controller:amqp
+  - rabbitmq-server:amqp
+- - nova-cloud-controller:quantum-network-service
+  - neutron-gateway:quantum-network-service
+- - nova-compute:neutron-plugin
+  - neutron-openvswitch:neutron-plugin
+- - neutron-openvswitch:amqp
+  - rabbitmq-server:amqp
+- - openstack-dashboard:identity-service
+  - keystone:identity-service
+- - openstack-dashboard:shared-db
+  - dashboard-mysql-router:shared-db
+- - nova-cloud-controller:shared-db
+  - nova-mysql-router:shared-db
+- - nova-cloud-controller:neutron-api
+  - neutron-api:neutron-api
+- - cinder:image-service
+  - glance:image-service
+- - cinder:amqp
+  - rabbitmq-server:amqp
+- - cinder:identity-service
+  - keystone:identity-service
+- - cinder:cinder-volume-service
+  - nova-cloud-controller:cinder-volume-service
+- - placement:shared-db
+  - placement-mysql-router:shared-db
+- - placement
+  - keystone
+- - placement
+  - nova-cloud-controller
+- - keystone-mysql-router:db-router
+  - mysql:db-router
+- - cinder-mysql-router:db-router
+  - mysql:db-router
+- - nova-mysql-router:db-router
+  - mysql:db-router
+- - glance-mysql-router:db-router
+  - mysql:db-router
+- - neutron-mysql-router:db-router
+  - mysql:db-router
+- - dashboard-mysql-router:db-router
+  - mysql:db-router
+- - placement-mysql-router:db-router
+  - mysql:db-router
+
+- - cinder-ceph:storage-backend
+  - cinder:storage-backend
+- - ceph-mon:client
+  - nova-compute:ceph
+- - nova-compute:ceph-access
+  - cinder-ceph:ceph-access
+- - cinder:shared-db
+  - cinder-mysql-router:shared-db
+- - ceph-mon:client
+  - cinder-ceph:ceph
+- - ceph-mon:client
+  - glance:ceph
+- - ceph-osd:mon
+  - ceph-mon:osd
+- - ceph-radosgw:mon
+  - ceph-mon:radosgw
+- - ceph-radosgw:identity-service
+  - keystone:identity-service
+
+# Swift relations
+- - swift-proxy:identity-service
+  - keystone:identity-service
+- - swift-proxy:swift-storage
+  - swift-storage-z1:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z2:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z3:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z4:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z5:swift-storage
+
+# Vault
+- - vault:shared-db
+  - vault-mysql-router:shared-db
+- - vault-mysql-router:db-router
+  - mysql:db-router
+- - neutron-api:certificates
+  - vault:certificates
+- - vault:certificates
+  - cinder:certificates
+- - vault:certificates
+  - glance:certificates
+- - vault:certificates
+  - keystone:certificates
+- - vault:certificates
+  - nova-cloud-controller:certificates
+- - vault:certificates
+  - openstack-dashboard:certificates
+- - vault:certificates
+  - placement:certificates
+- - vault:certificates
+  - swift-proxy:certificates
+
+series: jammy
+applications:
+  ceph-mon:
+    annotations:
+      gui-x: '750'
+      gui-y: '500'
+    charm: ch:ceph-mon
+    num_units: 3
+    options:
+      expected-osd-count: 3
+      # NOTE(lourot): our s390x test lab's LPARs have so little disk space that
+      # we need to tell ceph-mon to tolerate OSD disk usage up to 98% or it may
+      # refuse to start (default is 95%):
+      config-flags: "{'mon': {'mon data avail crit': 2}}"
+    to:
+    - 'lxd:1'
+    - 'lxd:2'
+    - 'lxd:3'
+    channel: *ceph-charm-channel
+  ceph-osd:
+    annotations:
+      gui-x: '1000'
+      gui-y: '500'
+    charm: ch:ceph-osd
+    num_units: 3
+    options:
+      osd-devices: /dev/sdb
+    to:
+    - '1'
+    - '2'
+    - '3'
+    channel: *ceph-charm-channel
+  ceph-radosgw:
+    annotations:
+      gui-x: '1000'
+      gui-y: '250'
+    charm: ch:ceph-radosgw
+    num_units: 1
+    to:
+    - lxd:0
+    channel: *ceph-charm-channel
+  cinder-mysql-router:
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  cinder:
+    annotations:
+      gui-x: '750'
+      gui-y: '0'
+    charm: ch:cinder
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      block-device: None
+      glance-api-version: 2
+      worker-multiplier: 0.25
+    to:
+    - lxd:1
+    channel: *openstack-charm-channel
+  cinder-ceph:
+    annotations:
+      gui-x: '750'
+      gui-y: '250'
+    charm: ch:cinder-ceph
+    num_units: 0
+    channel: *openstack-charm-channel
+  glance-mysql-router:
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  glance:
+    annotations:
+      gui-x: '250'
+      gui-y: '0'
+    charm: ch:glance
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      worker-multiplier: 0.25
+    to:
+    - lxd:0
+    channel: *openstack-charm-channel
+  keystone-mysql-router:
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  keystone:
+    annotations:
+      gui-x: '500'
+      gui-y: '0'
+    charm: ch:keystone
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      admin-password: openstack
+      worker-multiplier: 0.25
+    to:
+    - lxd:0
+    channel: *openstack-charm-channel
+  mysql:
+    annotations:
+      gui-x: '0'
+      gui-y: '250'
+    charm: ch:mysql-innodb-cluster
+    num_units: 3
+    options:
+      max-connections: 1000
+      innodb-buffer-pool-size: 256M
+    to:
+    - lxd:0
+    - lxd:3
+    - lxd:4
+    channel: *mysql-charm-channel
+  neutron-mysql-router:
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  neutron-api:
+    annotations:
+      gui-x: '500'
+      gui-y: '500'
+    charm: ch:neutron-api
+    num_units: 1
+    options:
+      manage-neutron-plugin-legacy-mode: true
+      openstack-origin: *openstack-origin
+      neutron-security-groups: true
+      flat-network-providers: physnet1
+      worker-multiplier: 0.25
+    to:
+    - lxd:4
+    channel: *openstack-charm-channel
+  placement-mysql-router:
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  placement:
+    annotations:
+      gui-x: '0'
+      gui-y: '500'
+    charm: ch:placement
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      worker-multiplier: 0.25
+    to:
+    - lxd:4
+    channel: *openstack-charm-channel
+  neutron-gateway:
+    annotations:
+      gui-x: '0'
+      gui-y: '0'
+    charm: ch:neutron-gateway
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      bridge-mappings: physnet1:br-ex
+      data-port: br-ex:encc003
+      worker-multiplier: 0.25
+    to:
+    - '0'
+    channel: *openstack-charm-channel
+  neutron-openvswitch:
+    annotations:
+      gui-x: '250'
+      gui-y: '500'
+    charm: ch:neutron-openvswitch
+    num_units: 0
+    channel: *openstack-charm-channel
+  nova-mysql-router:
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  nova-cloud-controller:
+    annotations:
+      gui-x: '0'
+      gui-y: '500'
+    charm: ch:nova-cloud-controller
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+      network-manager: Neutron
+      worker-multiplier: 0.25
+    to:
+    - lxd:2
+    channel: *openstack-charm-channel
+  nova-compute:
+    annotations:
+      gui-x: '250'
+      gui-y: '250'
+    charm: ch:nova-compute
+    num_units: 3
+    options:
+      config-flags: default_ephemeral_format=ext4
+      openstack-origin: *openstack-origin
+      enable-live-migration: true
+      enable-resize: true
+      migration-auth-type: ssh
+    to:
+    - '1'
+    - '2'
+    - '3'
+    channel: *openstack-charm-channel
+  dashboard-mysql-router:
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  openstack-dashboard:
+    annotations:
+      gui-x: '500'
+      gui-y: '-250'
+    charm: ch:openstack-dashboard
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    to:
+    - lxd:0
+    channel: *openstack-charm-channel
+  rabbitmq-server:
+    annotations:
+      gui-x: '500'
+      gui-y: '250'
+    charm: ch:rabbitmq-server
+    num_units: 1
+    to:
+    - lxd:0
+    channel: latest/edge
+  vault-mysql-router:
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  vault:
+    charm: ch:vault
+    num_units: 1
+    to:
+    - 'lxd:4'
+    channel: latest/edge
+  swift-proxy:
+    charm: ch:swift-proxy
+    num_units: 1
+    options:
+      zone-assignment: manual
+      replicas: 5
+      swift-hash: 62ce298d-cd4a-4087-b7f3-0c71df0127e0
+      openstack-origin: *openstack-origin
+    to:
+      - "lxd:0"
+    channel: *openstack-charm-channel
+  swift-storage-z1:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      zone: 1
+      block-device: /mnt/swift/swift_dist.img|20G
+      overwrite: "false"
+      openstack-origin: *openstack-origin
+    to:
+    - '0'
+    channel: *openstack-charm-channel
+  swift-storage-z2:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      zone: 2
+      block-device: /mnt/swift/swift_dist.img|20G
+      overwrite: "false"
+      openstack-origin: *openstack-origin
+    to:
+    - '1'
+    channel: *openstack-charm-channel
+  swift-storage-z3:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      zone: 3
+      block-device: /mnt/swift/swift_dist.img|20G
+      overwrite: "false"
+      openstack-origin: *openstack-origin
+    to:
+    - '2'
+    channel: *openstack-charm-channel
+  swift-storage-z4:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      zone: 4
+      block-device: /mnt/swift/swift_dist.img|20G
+      overwrite: "false"
+      openstack-origin: *openstack-origin
+    to:
+    - '3'
+    channel: *openstack-charm-channel
+  swift-storage-z5:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      zone: 5
+      block-device: /mnt/swift/swift_dist.img|20G
+      overwrite: "false"
+      openstack-origin: *openstack-origin
+    to:
+    - '4'
+    channel: *openstack-charm-channel

--- a/bundles/lpar/noble-caracal-ovn-edge.yaml
+++ b/bundles/lpar/noble-caracal-ovn-edge.yaml
@@ -1,0 +1,460 @@
+# Open Virtual Network (OVN) - requires Train or later
+#
+# NOTE: Please review the value for the configuration option
+#       `bridge-interface-mappings` for the `ovn-chassis` charm.
+#       Refer to the [Open Virtual Network (OVN)](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/app-ovn.html)
+#       section of the [OpenStack Charms Deployment Guide](https://docs.openstack.org/project-deploy-guide/charm-deployment-guide/latest/)
+#       for more information.
+---
+local_overlay_enabled: False
+series: jammy
+variables:
+  openstack-origin:        &openstack-origin        distro
+  openstack-charm-channel: &openstack-charm-channel latest/edge
+  ovn-charm-channel:       &ovn-charm-channel       latest/edge
+  ceph-charm-channel:      &ceph-charm-channel      latest/edge
+  mysql-charm-channel:     &mysql-charm-channel     latest/edge
+  data-port:               &data-port               br-ex:9e:5d:5f:52:4e:b0
+  worker-multiplier:       &worker-multiplier       0.25
+  osd-devices:             &osd-devices             /dev/disk/by-label/ceph
+  expected-osd-count:      &expected-osd-count      3
+  expected-mon-count:      &expected-mon-count      3
+machines:
+  '0':
+    series: jammy
+    constraints: "arch=s390x"
+  '1':
+    series: jammy
+    constraints: "arch=s390x"
+  '2':
+    series: jammy
+    constraints: "arch=s390x"
+  '3':
+    series: jammy
+    constraints: "arch=s390x"
+  '4':
+    series: jammy
+    constraints: "arch=s390x"
+relations:
+- - nova-compute:amqp
+  - rabbitmq-server:amqp
+- - keystone:shared-db
+  - keystone-mysql-router:shared-db
+- - nova-cloud-controller:identity-service
+  - keystone:identity-service
+- - glance:identity-service
+  - keystone:identity-service
+- - neutron-api:identity-service
+  - keystone:identity-service
+- - neutron-api:shared-db
+  - neutron-mysql-router:shared-db
+- - neutron-api:amqp
+  - rabbitmq-server:amqp
+- - glance:shared-db
+  - glance-mysql-router:shared-db
+- - glance:amqp
+  - rabbitmq-server:amqp
+- - nova-cloud-controller:image-service
+  - glance:image-service
+- - nova-compute:image-service
+  - glance:image-service
+- - nova-cloud-controller:cloud-compute
+  - nova-compute:cloud-compute
+- - nova-cloud-controller:amqp
+  - rabbitmq-server:amqp
+- - openstack-dashboard:identity-service
+  - keystone:identity-service
+- - openstack-dashboard:shared-db
+  - dashboard-mysql-router:shared-db
+- - nova-cloud-controller:shared-db
+  - nova-mysql-router:shared-db
+- - nova-cloud-controller:neutron-api
+  - neutron-api:neutron-api
+- - cinder:image-service
+  - glance:image-service
+- - cinder:amqp
+  - rabbitmq-server:amqp
+- - cinder:identity-service
+  - keystone:identity-service
+- - cinder:cinder-volume-service
+  - nova-cloud-controller:cinder-volume-service
+- - placement:shared-db
+  - placement-mysql-router:shared-db
+- - placement
+  - keystone
+- - placement
+  - nova-cloud-controller
+- - keystone-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - cinder-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - nova-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - glance-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - neutron-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - dashboard-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - placement-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+
+- - cinder-ceph:storage-backend
+  - cinder:storage-backend
+- - ceph-mon:client
+  - nova-compute:ceph
+- - nova-compute:ceph-access
+  - cinder-ceph:ceph-access
+- - cinder:shared-db
+  - cinder-mysql-router:shared-db
+- - ceph-mon:client
+  - cinder-ceph:ceph
+- - ceph-mon:client
+  - glance:ceph
+- - ceph-osd:mon
+  - ceph-mon:osd
+- - ceph-radosgw:mon
+  - ceph-mon:radosgw
+- - ceph-radosgw:identity-service
+  - keystone:identity-service
+- - vault:shared-db
+  - vault-mysql-router:shared-db
+- - vault-mysql-router:db-router
+  - mysql-innodb-cluster:db-router
+- - neutron-api-plugin-ovn:neutron-plugin
+  - neutron-api:neutron-plugin-api-subordinate
+- - ovn-central:certificates
+  - vault:certificates
+- - ovn-central:ovsdb-cms
+  - neutron-api-plugin-ovn:ovsdb-cms
+- - neutron-api:certificates
+  - vault:certificates
+- - ovn-chassis:nova-compute
+  - nova-compute:neutron-plugin
+- - ovn-chassis:certificates
+  - vault:certificates
+- - ovn-chassis:ovsdb
+  - ovn-central:ovsdb
+- - vault:certificates
+  - neutron-api-plugin-ovn:certificates
+- - vault:certificates
+  - cinder:certificates
+- - vault:certificates
+  - glance:certificates
+- - vault:certificates
+  - keystone:certificates
+- - vault:certificates
+  - nova-cloud-controller:certificates
+- - vault:certificates
+  - openstack-dashboard:certificates
+- - vault:certificates
+  - placement:certificates
+
+# Swift relations
+- - swift-proxy:identity-service
+  - keystone:identity-service
+- - swift-proxy:swift-storage
+  - swift-storage-z1:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z2:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z3:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z4:swift-storage
+- - swift-proxy:swift-storage
+  - swift-storage-z5:swift-storage
+- - vault:certificates
+  - swift-proxy:certificates
+
+applications:
+  ceph-mon:
+    annotations:
+      gui-x: '750'
+      gui-y: '500'
+    charm: ch:ceph-mon
+    num_units: 3
+    options:
+      expected-osd-count: *expected-osd-count
+      monitor-count: *expected-mon-count
+    to:
+    - 'lxd:0'
+    - 'lxd:1'
+    - 'lxd:2'
+    channel: *ceph-charm-channel
+  ceph-osd:
+    annotations:
+      gui-x: '1000'
+      gui-y: '500'
+    charm: ch:ceph-osd
+    num_units: 3
+    options:
+      osd-devices: *osd-devices
+    to:
+    - '0'
+    - '1'
+    - '2'
+    channel: *ceph-charm-channel
+  ceph-radosgw:
+    annotations:
+      gui-x: '1000'
+      gui-y: '250'
+    charm: ch:ceph-radosgw
+    num_units: 1
+    to:
+    - 'lxd:3'
+    channel: *ceph-charm-channel
+  cinder-mysql-router:
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  cinder:
+    annotations:
+      gui-x: '750'
+      gui-y: '0'
+    charm: ch:cinder
+    num_units: 1
+    options:
+      block-device: None
+      glance-api-version: 2
+      worker-multiplier: *worker-multiplier
+      openstack-origin: *openstack-origin
+    to:
+    - 'lxd:3'
+    channel: *openstack-charm-channel
+  cinder-ceph:
+    annotations:
+      gui-x: '750'
+      gui-y: '250'
+    charm: ch:cinder-ceph
+    num_units: 0
+    channel: *openstack-charm-channel
+  glance-mysql-router:
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  glance:
+    annotations:
+      gui-x: '250'
+      gui-y: '0'
+    charm: ch:glance
+    num_units: 1
+    options:
+      worker-multiplier: *worker-multiplier
+      openstack-origin: *openstack-origin
+    to:
+    - 'lxd:4'
+    channel: *openstack-charm-channel
+  keystone-mysql-router:
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  keystone:
+    annotations:
+      gui-x: '500'
+      gui-y: '0'
+    charm: ch:keystone
+    num_units: 1
+    options:
+      worker-multiplier: *worker-multiplier
+      openstack-origin: *openstack-origin
+    to:
+    - 'lxd:3'
+    channel: *openstack-charm-channel
+  neutron-mysql-router:
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  neutron-api:
+    annotations:
+      gui-x: '500'
+      gui-y: '500'
+    charm: ch:neutron-api
+    num_units: 1
+    options:
+      # NOTE(fnordahl): At current state of upstream Neutron development this
+      # is a requirement.  Remove once fixed upstream.
+      enable-ml2-port-security: true
+      neutron-security-groups: true
+      flat-network-providers: physnet1
+      worker-multiplier: *worker-multiplier
+      openstack-origin: *openstack-origin
+      manage-neutron-plugin-legacy-mode: false
+    to:
+    - 'lxd:4'
+    channel: *openstack-charm-channel
+  placement-mysql-router:
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  placement:
+    annotations:
+      gui-x: '0'
+      gui-y: '500'
+    charm: ch:placement
+    num_units: 1
+    options:
+      worker-multiplier: *worker-multiplier
+      openstack-origin: *openstack-origin
+    to:
+    - 'lxd:0'
+    channel: *openstack-charm-channel
+  nova-mysql-router:
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  nova-cloud-controller:
+    annotations:
+      gui-x: '0'
+      gui-y: '500'
+    charm: ch:nova-cloud-controller
+    num_units: 1
+    options:
+      network-manager: Neutron
+      worker-multiplier: *worker-multiplier
+      openstack-origin: *openstack-origin
+    to:
+    - 'lxd:1'
+    channel: *openstack-charm-channel
+  nova-compute:
+    annotations:
+      gui-x: '250'
+      gui-y: '250'
+    charm: ch:nova-compute
+    num_units: 3
+    options:
+      config-flags: default_ephemeral_format=ext4
+      enable-live-migration: true
+      enable-resize: true
+      migration-auth-type: ssh
+      openstack-origin: *openstack-origin
+    to:
+    - '0'
+    - '1'
+    - '2'
+    channel: *openstack-charm-channel
+  dashboard-mysql-router:
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  openstack-dashboard:
+    annotations:
+      gui-x: '500'
+      gui-y: '-250'
+    charm: ch:openstack-dashboard
+    num_units: 1
+    options:
+      openstack-origin: *openstack-origin
+    to:
+    - 'lxd:4'
+    channel: *openstack-charm-channel
+  rabbitmq-server:
+    annotations:
+      gui-x: '500'
+      gui-y: '250'
+    charm: ch:rabbitmq-server
+    num_units: 1
+    to:
+    - 'lxd:3'
+    channel: latest/edge
+  mysql-innodb-cluster:
+    charm: ch:mysql-innodb-cluster
+    num_units: 3
+    options:
+      max-connections: 1000
+      innodb-buffer-pool-size: 256M
+    to:
+    - 'lxd:0'
+    - 'lxd:1'
+    - 'lxd:2'
+    channel: *mysql-charm-channel
+  neutron-api-plugin-ovn:
+    charm: ch:neutron-api-plugin-ovn
+    channel: *openstack-charm-channel
+  ovn-central:
+    charm: ch:ovn-central
+    num_units: 3
+    options:
+      source: *openstack-origin
+    to:
+    - 'lxd:0'
+    - 'lxd:1'
+    - 'lxd:2'
+    channel: *ovn-charm-channel
+  ovn-chassis:
+    charm: ch:ovn-chassis
+    comment: |
+      Please update the `bridge-interface-mappings` to values suitable for the
+      hardware used in your deployment.  See the referenced documentation at
+      the top of this file.
+    options:
+      ovn-bridge-mappings: physnet1:br-ex
+      bridge-interface-mappings: *data-port
+    channel: *ovn-charm-channel
+  vault-mysql-router:
+    charm: ch:mysql-router
+    channel: *mysql-charm-channel
+  vault:
+    charm: ch:vault
+    num_units: 1
+    to:
+    - 'lxd:4'
+    channel: latest/edge
+  swift-proxy:
+    charm: ch:swift-proxy
+    num_units: 1
+    options:
+      zone-assignment: manual
+      replicas: 5
+      swift-hash: 62ce298d-cd4a-4087-b7f3-0c71df0127e0
+      openstack-origin: *openstack-origin
+    to:
+      - "lxd:0"
+    channel: *openstack-charm-channel
+  swift-storage-z1:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      zone: 1
+      block-device: /mnt/swift/swift_dist.img|20G
+      overwrite: "false"
+      openstack-origin: *openstack-origin
+    to:
+    - '0'
+    channel: *openstack-charm-channel
+  swift-storage-z2:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      zone: 2
+      block-device: /mnt/swift/swift_dist.img|20G
+      overwrite: "false"
+      openstack-origin: *openstack-origin
+    to:
+    - '1'
+    channel: *openstack-charm-channel
+  swift-storage-z3:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      zone: 3
+      block-device: /mnt/swift/swift_dist.img|20G
+      overwrite: "false"
+      openstack-origin: *openstack-origin
+    to:
+    - '2'
+    channel: *openstack-charm-channel
+  swift-storage-z4:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      zone: 4
+      block-device: /mnt/swift/swift_dist.img|20G
+      overwrite: "false"
+      openstack-origin: *openstack-origin
+    to:
+    - '3'
+    channel: *openstack-charm-channel
+  swift-storage-z5:
+    charm: ch:swift-storage
+    num_units: 1
+    options:
+      zone: 5
+      block-device: /mnt/swift/swift_dist.img|20G
+      overwrite: "false"
+      openstack-origin: *openstack-origin
+    to:
+    - '4'
+    channel: *openstack-charm-channel


### PR DESCRIPTION
Bundles to deploy OpenStack in the following configurations:

- jammy-caracal
- jammy-caracal-ovn
- noble-caracal
- noble-caracal-ovn

The charms channels used are:

- latest/edge for OpenStack charms
- latest/edge for Ceph charms
- latest/edge for OVN charms

latest/edge is used, because noble support is only available in the development channel (non released)